### PR TITLE
Use Redux store enhancer API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.createOfflineStore = undefined;
+exports.offline = undefined;
 
 var _redux = require('redux');
 
@@ -26,37 +26,44 @@ var babelPluginFlowReactPropTypes_proptype_Config = require('./types').babelPlug
 // eslint-disable-next-line no-unused-vars
 var persistor = void 0;
 
-var createOfflineStore = exports.createOfflineStore = function createOfflineStore(reducer, preloadedState, enhancer) {
-  var userConfig = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+var offline = exports.offline = function offline() {
+  var userConfig = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  return function (createStore) {
+    return function (reducer, preloadedState) {
+      var enhancer = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function (x) {
+        return x;
+      };
 
-  console.log('user config', userConfig);
-  var config = (0, _config.applyDefaults)(userConfig);
+      console.log('user config', userConfig);
+      var config = (0, _config.applyDefaults)(userConfig);
 
-  console.log('Creating offline store', config);
+      console.log('Creating offline store', config);
 
-  // wraps userland reducer with a top-level
-  // reducer that handles offline state updating
-  var offlineReducer = (0, _updater.enhanceReducer)(reducer);
+      // wraps userland reducer with a top-level
+      // reducer that handles offline state updating
+      var offlineReducer = (0, _updater.enhanceReducer)(reducer);
 
-  var offlineMiddleware = (0, _redux.applyMiddleware)((0, _middleware.createOfflineMiddleware)(config));
+      var offlineMiddleware = (0, _redux.applyMiddleware)((0, _middleware.createOfflineMiddleware)(config));
 
-  // create autoRehydrate enhancer if required
-  var offlineEnhancer = config.persist && config.rehydrate ? (0, _redux.compose)(offlineMiddleware, enhancer, (0, _reduxPersist.autoRehydrate)()) : (0, _redux.compose)(offlineMiddleware, enhancer);
+      // create autoRehydrate enhancer if required
+      var offlineEnhancer = config.persist && config.rehydrate ? (0, _redux.compose)(offlineMiddleware, enhancer, (0, _reduxPersist.autoRehydrate)()) : (0, _redux.compose)(offlineMiddleware, enhancer);
 
-  // create store
-  var store = (0, _redux.createStore)(offlineReducer, preloadedState, offlineEnhancer);
+      // create store
+      var store = createStore(offlineReducer, preloadedState, offlineEnhancer);
 
-  // launch store persistor
-  if (config.persist) {
-    persistor = config.persist(store, config.persistOptions);
-  }
+      // launch store persistor
+      if (config.persist) {
+        persistor = config.persist(store, config.persistOptions);
+      }
 
-  // launch network detector
-  if (config.detectNetwork) {
-    config.detectNetwork(function (online) {
-      store.dispatch((0, _actions.networkStatusChanged)(online));
-    });
-  }
+      // launch network detector
+      if (config.detectNetwork) {
+        config.detectNetwork(function (online) {
+          store.dispatch((0, _actions.networkStatusChanged)(online));
+        });
+      }
 
-  return store;
+      return store;
+    };
+  };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 /*global $Shape*/
 import type { Config } from './types';
-import { applyMiddleware, createStore, compose } from 'redux';
+import { applyMiddleware, compose } from 'redux';
 import { autoRehydrate } from 'redux-persist';
 import { createOfflineMiddleware } from './middleware';
 import { enhanceReducer } from './updater';
@@ -13,11 +13,10 @@ import { networkStatusChanged } from './actions';
 // eslint-disable-next-line no-unused-vars
 let persistor;
 
-export const createOfflineStore = (
+export const offline = (userConfig: $Shape<Config> = {}) => (createStore: any) => (
   reducer: any,
   preloadedState: any,
-  enhancer: any,
-  userConfig: $Shape<Config> = {}
+  enhancer: any
 ) => {
   console.log('user config', userConfig);
   const config = applyDefaults(userConfig);

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ let persistor;
 export const offline = (userConfig: $Shape<Config> = {}) => (createStore: any) => (
   reducer: any,
   preloadedState: any,
-  enhancer: any
+  enhancer: any = x => x
 ) => {
   console.log('user config', userConfig);
   const config = applyDefaults(userConfig);


### PR DESCRIPTION
This PR implements the Redux store enhancer API as requested in #3.

This would be a breaking change because the API would now be the following:

```diff
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, createStore, compose } from 'redux';
+import { offline } from 'redux-offline';
+import offlineConfig from 'redux-offline/lib/defaults';

 // ...

 const store = createStore(
   reducer,
   preloadedState,
-  applyMiddleware(middleware)
+  compose(offline(offlineConfig), applyMiddleware(middleware))
 );
```

The names used can definitely be changed. This is just an initial POC to show how easy it is to implement.

If help is needed for better Flow types, I wouldn't mind helping out with that as well.

Let me know what you think, @jevakallio!

🍺 