### PR TITLE
takes only OfflineActions. fix #23

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -50,7 +50,9 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (next
 
   // find any actions to send, if any
   const state: AppState = store.getState();
-  const actions = take(state, config);
+
+  // take only if we have an OfflineAction
+  const actions = result && result.meta && result.meta.offline ? take(state, config) : [];
 
   // if the are any actions in the queue that we are not
   // yet processing, send those actions


### PR DESCRIPTION
As stated in #23 redux-offline currently takes actions multiple times if unrelated are dispatched during the time the `effect` reconciler processes the request and dispatching the `commit` action.

This PR fixes this behaviour by taking only actions which are related to the redux-offline middleware.