### PR TITLE
Expose redux-persist callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,13 @@ const config = {
 };
 ```
 
+You can pass the callback for redux-persist as well. This function would be called when rehydration is complete. It's useful if you want to delay rendering until rehydration is complete. You can define it in `config.persistCallback`:
+```js
+const config = {
+  persistCallback: () => { /*...*/ }
+};
+```
+
 If you want to replace redux-persist entirely **(not recommended)**, you can override `config.persist`. The function receives the store instance as a first parameter, and is responsible for setting any subscribers to listen for store changes to persist it.
 ```js
 const config = {

--- a/lib/defaults/persist.native.js
+++ b/lib/defaults/persist.native.js
@@ -14,6 +14,6 @@ var _reactNative = require('react-native');
 
 var _reduxPersist = require('redux-persist');
 
-exports.default = function (store, options) {
-  return (0, _reduxPersist.persistStore)(store, _extends({ storage: _reactNative.AsyncStorage }, options));
+exports.default = function (store, options, callback) {
+  return (0, _reduxPersist.persistStore)(store, _extends({ storage: _reactNative.AsyncStorage }, options), callback);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ var createOfflineStore = exports.createOfflineStore = function createOfflineStor
 
   // launch store persistor
   if (config.persist) {
-    persistor = config.persist(store, config.persistOptions);
+    persistor = config.persist(store, config.persistOptions, config.persistCallback);
   }
 
   // launch network detector

--- a/lib/types.js
+++ b/lib/types.js
@@ -160,6 +160,7 @@ Object.defineProperty(module.exports, "babelPluginFlowReactPropTypes_proptype_Co
     effect: require("react").PropTypes.func.isRequired,
     retry: require("react").PropTypes.func.isRequired,
     discard: require("react").PropTypes.func.isRequired,
-    persistOptions: require("react").PropTypes.shape({}).isRequired
+    persistOptions: require("react").PropTypes.shape({}).isRequired,
+    persistCallback: require("react").PropTypes.func.isRequired
   })
 });

--- a/src/defaults/persist.native.js
+++ b/src/defaults/persist.native.js
@@ -4,6 +4,6 @@
 import { AsyncStorage } from 'react-native'; //eslint-disable-line import/no-unresolved
 import { persistStore } from 'redux-persist';
 
-export default (store: any, options: {}) => {
-  return persistStore(store, { storage: AsyncStorage, ...options });
+export default (store: any, options: {}, callback: any) => {
+  return persistStore(store, { storage: AsyncStorage, ...options }, callback);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ export const createOfflineStore = (
 
   // launch store persistor
   if (config.persist) {
-    persistor = config.persist(store, config.persistOptions);
+    persistor = config.persist(store, config.persistOptions, config.persistCallback);
   }
 
   // launch network detector

--- a/src/types.js
+++ b/src/types.js
@@ -55,5 +55,6 @@ export type Config = {
   effect: (effect: any, action: OfflineAction) => Promise<*>,
   retry: (action: OfflineAction, retries: number) => ?number,
   discard: (error: any, action: OfflineAction, retries: number) => boolean,
-  persistOptions: {}
+  persistOptions: {},
+  persistCallback: (callback: any) => any
 };


### PR DESCRIPTION
Exposes the the third argument for redux-persist's `persistStore` which allows the user to set a callback that is called when rehydration is complete.