### PR TITLE
Allow to pass rehydration callback function

### DIFF
--- a/lib/defaults/persist.native.js
+++ b/lib/defaults/persist.native.js
@@ -14,6 +14,6 @@ var _reactNative = require('react-native');
 
 var _reduxPersist = require('redux-persist');
 
-exports.default = function (store, options) {
-  return (0, _reduxPersist.persistStore)(store, _extends({ storage: _reactNative.AsyncStorage }, options));
+exports.default = function (store, options, persistCallback) {
+  return (0, _reduxPersist.persistStore)(store, _extends({ storage: _reactNative.AsyncStorage }, options), persistCallback);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ var persistor = void 0;
 
 var createOfflineStore = exports.createOfflineStore = function createOfflineStore(reducer, preloadedState, enhancer) {
   var userConfig = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+  var persistCallback = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : null;
 
   console.log('user config', userConfig);
   var config = (0, _config.applyDefaults)(userConfig);
@@ -48,7 +49,7 @@ var createOfflineStore = exports.createOfflineStore = function createOfflineStor
 
   // launch store persistor
   if (config.persist) {
-    persistor = config.persist(store, config.persistOptions);
+    persistor = config.persist(store, config.persistOptions, persistCallback ? () => persistCallback(store) : null);
   }
 
   // launch network detector


### PR DESCRIPTION
Via redux-offline we can not take action after rehydration was completed, like redux-persist can do.