### PR TITLE
Resolves the issue where offline outbox wasn't restored from redux-pe…

### DIFF
--- a/src/updater.js
+++ b/src/updater.js
@@ -57,8 +57,7 @@ const offlineUpdater = function offlineUpdater(
   }
 
   if (action.type === PERSIST_REHYDRATE) {
-    if (action.payload.offline) delete action.payload.offline.online;
-    return { ...state, ...action.payload.offline, busy: false };
+    return { ...state, ...action.payload.offline, online: state.online, busy: false };
   }
 
   if (action.type === OFFLINE_SCHEDULE_RETRY) {

--- a/src/updater.js
+++ b/src/updater.js
@@ -57,6 +57,7 @@ const offlineUpdater = function offlineUpdater(
   }
 
   if (action.type === PERSIST_REHYDRATE) {
+    if (action.payload.offline) delete action.payload.offline.online;
     return { ...state, ...action.payload.offline, busy: false };
   }
 

--- a/src/updater.js
+++ b/src/updater.js
@@ -57,7 +57,7 @@ const offlineUpdater = function offlineUpdater(
   }
 
   if (action.type === PERSIST_REHYDRATE) {
-    return { ...state, busy: false };
+    return { ...state, ...action.payload.offline, busy: false };
   }
 
   if (action.type === OFFLINE_SCHEDULE_RETRY) {


### PR DESCRIPTION
Resolves #59

@DylanGriffith found that due to redux-offline mutating the state of the offline reducer during a PERSIST_REHYDRATE. The outbox was not being correctly restored from persistence.

This solves the problem by merging the default state, with the persisted state, and modifying the busy state. We must merge the default state, in the scenario that the persisted state is undefined. (Alternatively, we could make an undefined check, Might be better..?)