### PR TITLE
Check for 'offline' key in state before trying to send actions

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -50,8 +50,15 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (next
   // allow other middleware to do their things
   const result = next(action);
 
-  // find any actions to send, if any
+  // load application state
   const state: AppState = store.getState();
+
+  // if state hasn't been initialized, just return result
+  if (!state || !state.offline) {
+    return result;
+  }
+
+  // find any actions to send, if any
   const actions = take(state, config);
 
   // if the are any actions in the queue that we are not


### PR DESCRIPTION
This helps address #66 and perhaps #57 by letting the middleware just skip processing if the state hasn’t been initialized with the ‘offline’ reducer. This can happen if you have another enhancer that tries to do tricky things with the store (like devtools) :)