### PR TITLE
Feat: react-native detectNetwork includes netInfo

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -5,10 +5,11 @@ import {
   OFFLINE_BUSY
 } from './constants';
 
-export const networkStatusChanged = online => ({
+export const networkStatusChanged = ({ online, netInfo }) => ({
   type: OFFLINE_STATUS_CHANGED,
   payload: {
-    online
+    online,
+    netInfo
   }
 });
 

--- a/src/defaults/detectNetwork.native.js
+++ b/src/defaults/detectNetwork.native.js
@@ -102,7 +102,7 @@ class DetectNetwork {
    * @private
    */
   _addListeners() {
-    NetInfo.addEventListener('change', (reach) => {
+    NetInfo.addEventListener('change', reach => {
       this._update(reach);
     });
     AppState.addEventListener('change', this._init);

--- a/src/defaults/detectNetwork.native.js
+++ b/src/defaults/detectNetwork.native.js
@@ -1,17 +1,86 @@
-import { AppState, NetInfo } from 'react-native'; //eslint-disable-line
+/* eslint no-underscore-dangle: 0 */
+import { AppState, NetInfo } from 'react-native'; // eslint-disable-line import/no-unresolved
 
-export default callback => {
-  let wasOnline;
-  const updateState = isOnline => {
-    if (wasOnline !== isOnline) {
-      wasOnline = isOnline;
-      callback(isOnline);
+class DetectNetwork {
+  constructor(callback) {
+    this._reach = null;
+    this._isConnected = null;
+    this._isConnectionExpensive = null;
+    this._callback = callback;
+
+    this._init();
+    this._addListeners();
+  }
+
+  /**
+   * Sets the connection reachability prop
+   * @param reach - connection reachability.
+   *     - iOS: [none, wifi, cell, unknown]
+   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI, MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
+   * @private
+   */
+  _setReach = (reach) => {
+    this._reach = reach.toUpperCase();
+    this._setIsConnected(reach.toUpperCase());
+  }
+  /**
+   * Sets the isConnected prop depending on the connection reachability's value
+   * @param reach
+   * @private
+   */
+  _setIsConnected = (reach) => {
+    this._isConnected = (reach !== 'NONE' && reach !== 'UNKNOWN');
+  }
+  /**
+   * Sets the isConnectionExpensive prop
+   * @returns {Promise.<void>}
+   * @private
+   */
+  _setIsConnectionExpensive = async () => {
+    try {
+      this._isConnectionExpensive = await NetInfo.isConnectionExpensive();
+    } catch (err) {
+      // err means that isConnectionExpensive is not supported
+      this._isConnectionExpensive = null;
     }
-  };
+  }
+  /**
+   * Fetches and sets the connection reachability and the isConnected props
+   * @returns {Promise.<void>}
+   * @private
+   */
+  _init = async () => {
+    this._setReach(await NetInfo.fetch());
+    this._updateState();
+  }
 
-  NetInfo.isConnected.addEventListener('change', updateState);
-  NetInfo.isConnected.fetch().then(updateState);
-  AppState.addEventListener('change', () => {
-    NetInfo.isConnected.fetch().then(updateState);
-  });
-};
+  /**
+   * Adds listeners for when connection reachability and app state changes to update props
+   * @private
+   */
+  _addListeners() {
+    NetInfo.addEventListener('change', (reach) => {
+      this._setReach(reach);
+      this._updateState();
+    });
+    AppState.addEventListener('change', this._init);
+  }
+
+  /**
+   * Executes the given callback to update redux's store with the new internal props
+   * @returns {Promise.<void>}
+   * @private
+   */
+  _updateState = async () => {
+    await this._setIsConnectionExpensive();
+    this._callback({
+      online: this._isConnected,
+      netInfo: {
+        isConnectionExpensive: this._isConnectionExpensive,
+        reach: this._reach
+      }
+    });
+  }
+}
+
+export default callback => new DetectNetwork(callback);

--- a/src/defaults/detectNetwork.native.js
+++ b/src/defaults/detectNetwork.native.js
@@ -13,65 +13,108 @@ class DetectNetwork {
   }
 
   /**
-   * Sets the connection reachability prop
-   * @param reach - connection reachability.
+   * Check props for changes
+   * @param {string} reach - connection reachability.
    *     - iOS: [none, wifi, cell, unknown]
-   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI, MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
+   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
+   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
+   * @returns {boolean} - Whether the connection reachability or the connection props have changed
    * @private
    */
-  _setReach = (reach) => {
-    this._reach = reach.toUpperCase();
-    this._setIsConnected(reach.toUpperCase());
+  _hasChanged = reach => {
+    if (this._reach !== reach) {
+      return true;
+    }
+    if (this._isConnected !== this._getConnection(reach)) {
+      return true;
+    }
+    return false;
   }
   /**
-   * Sets the isConnected prop depending on the connection reachability's value
-   * @param reach
+   * Sets the connection reachability prop
+   * @param {string} reach - connection reachability.
+   *     - iOS: [none, wifi, cell, unknown]
+   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
+   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
+   * @returns {void}
    * @private
    */
-  _setIsConnected = (reach) => {
-    this._isConnected = (reach !== 'NONE' && reach !== 'UNKNOWN');
+  _setReach = reach => {
+    this._reach = reach;
+    this._isConnected = this._getConnection(reach);
+  }
+  /**
+   * Gets the isConnected prop depending on the connection reachability's value
+   * @param {string} reach - connection reachability.
+   *     - iOS: [none, wifi, cell, unknown]
+   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
+   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
+   * @returns {void}
+   * @private
+   */
+  _getConnection = reach => {
+    return reach !== 'NONE' && reach !== 'UNKNOWN';
   }
   /**
    * Sets the isConnectionExpensive prop
-   * @returns {Promise.<void>}
+   * @returns {Promise.<void>} Resolves to true if connection is expensive,
+   * false if not, and null if not supported.
    * @private
    */
   _setIsConnectionExpensive = async () => {
     try {
       this._isConnectionExpensive = await NetInfo.isConnectionExpensive();
     } catch (err) {
-      // err means that isConnectionExpensive is not supported
+      // err means that isConnectionExpensive is not supported in iOS
       this._isConnectionExpensive = null;
     }
   }
   /**
    * Fetches and sets the connection reachability and the isConnected props
-   * @returns {Promise.<void>}
+   * @returns {Promise.<void>} Resolves when the props have been
+   * initialized and update.
    * @private
    */
   _init = async () => {
-    this._setReach(await NetInfo.fetch());
-    this._updateState();
+    const reach = await NetInfo.fetch();
+    this._update(reach);
+  }
+  /**
+   * Check changes on props and store and dispatch if neccesary
+   * @param {string} reach - connection reachability.
+   *     - iOS: [none, wifi, cell, unknown]
+   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
+   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
+   * @returns {void}
+   * @private
+   */
+  _update = reach => {
+    const normalizedReach = reach.toUpperCase();
+    if (this._hasChanged(normalizedReach)) {
+      this._setReach(normalizedReach);
+      this._dispatch();
+    }
   }
 
   /**
    * Adds listeners for when connection reachability and app state changes to update props
+   * @returns {void}
    * @private
    */
   _addListeners() {
     NetInfo.addEventListener('change', (reach) => {
-      this._setReach(reach);
-      this._updateState();
+      this._update(reach);
     });
     AppState.addEventListener('change', this._init);
   }
 
   /**
    * Executes the given callback to update redux's store with the new internal props
-   * @returns {Promise.<void>}
+   * @returns {Promise.<void>} Resolves after fetching the isConnectionExpensive
+   * and dispatches actions
    * @private
    */
-  _updateState = async () => {
+  _dispatch = async () => {
     await this._setIsConnectionExpensive();
     this._callback({
       online: this._isConnected,

--- a/src/updater.js
+++ b/src/updater.js
@@ -53,7 +53,7 @@ const offlineUpdater = function offlineUpdater(
     action.payload &&
     typeof action.payload.online === 'boolean'
   ) {
-    return { ...state, online: action.payload.online };
+    return { ...state, online: action.payload.online, netInfo: action.payload.netInfo };
   }
 
   if (action.type === PERSIST_REHYDRATE) {

--- a/src/updater.js
+++ b/src/updater.js
@@ -38,7 +38,11 @@ const initialState: OfflineState = {
   receipts: [],
   retryToken: 0,
   retryCount: 0,
-  retryScheduled: false
+  retryScheduled: false,
+  netInfo: {
+    isConnectionExpensive: null,
+    reach: 'NONE'
+  }
 };
 
 // @TODO: the typing of this is all kinds of wack


### PR DESCRIPTION
This PR includes the following:
- Extends support of react-native NetInfo props to include `reach` & `isConnectionExpensive`.

**What is NetInfo and what are the `reach` and the `isConnectionExpensive` props for?**
> NetInfo exposes info about online/offline status

Note: `isConnectionExpensive` is only supported on android, in iOS it will default to null.

```js
   * {string} reach - connection reachability.
   *     - iOS: ['NONE', 'WIFI', 'CELL', 'UNKNOWN']
   *     - Android: ['NONE', 'BLUETOOTH', 'DUMMY', 'ETHERNET', 'MOBILE', 'MOBILE_DUN', 
   *       'MOBILE_HIPRI', 'MOBILE_MMS', 'MOBILE_SUPL', 'VPN', 'WIFI', 'WIMAX', 'UNKNOWN']

   * {boolean} isConnectionExpensive - Available on Android. Detect if the current active connection 
   * is metered or not. A network is classified as metered when the user is sensitive to heavy data 
   * usage on that connection due to monetary costs, data limitations or battery/performance issues.
   *    - Connection is metered: true|false
   *    - Not supported: null
```
We save react-native's NetInfo into the offline reducer with the following values:

```js
netInfo: {
  reach: 'WIFI' || 'CELL' || ... (see documentation above)
  isConnectionExpensive: true|false|null
}
```