### PR TITLE
Immutable root state

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ const action = userId => ({
   meta: {
     offline: {
       effect: //...,
-      rollback: { type: 'FOLLOW_USER_ROLLBACK', meta: { userId }}  
+      rollback: { type: 'FOLLOW_USER_ROLLBACK', meta: { userId }}
      }
   }
 });
@@ -178,7 +178,7 @@ const completeOrder = (orderId, lineItems) => ({
     offline: {
       effect: //...,
       commit: { type: 'COMPLETE_ORDER_COMMIT', meta: { orderId }},
-      rollback: { type: 'COMPLETE_ORDER_ROLLBACK', meta: { orderId }}  
+      rollback: { type: 'COMPLETE_ORDER_ROLLBACK', meta: { orderId }}
      }
   }
 });
@@ -198,7 +198,7 @@ const ordersReducer = (state, action) {
       };
     case 'COMPLETE_ORDER_ROLLBACK':
       return {
-        ...state,   
+        ...state,
         error: action.payload,
         submitting: omit(state.submitting, [action.meta.orderId])
       };
@@ -296,11 +296,14 @@ Redux Offline supports the following configuration properties:
 ```js
 export type Config = {
   detectNetwork: (callback: NetworkCallback) => void,
-  persist: (store: any) => any,
   effect: (effect: any, action: OfflineAction) => Promise<*>,
   retry: (action: OfflineAction, retries: number) => ?number,
   discard: (error: any, action: OfflineAction, retries: number) => boolean,
-  persistOptions: {}
+  persist: (store: any) => any,
+  persistOptions: {},
+  persistCallback: (callback: any) => any,
+  persistAutoRehydrate: (config: ?{}) => (next: any) => any,
+  offlineStateLens: (state: any) => { get: OfflineState, set: (offlineState: ?OfflineState) => any }
 };
 ```
 
@@ -359,7 +362,7 @@ const store = createStore(
   preloadedState,
 -  middleware
 +  compose(middleware, offline(myConfig))
- myConfig  
+ myConfig
 );
 ```
 
@@ -396,6 +399,15 @@ You can pass the callback for redux-persist as well. This function would be call
 ```js
 const config = {
   persistCallback: () => { /*...*/ }
+};
+```
+
+You can pass your persistAutoRehydrate method. For example in this way you can add a logger to the persistor.
+```js
+import { autoRehydrate } from 'redux-persist';
+
+const config = {
+  persistAutoRehydrate: () => autoRehydrate({log: true})
 };
 ```
 
@@ -466,10 +478,11 @@ Background sync is not yet supported. Coming soon.
 
 #### Use an [Immutable](https://facebook.github.io/immutable-js/) store
 
-Stores that implement the entire store as an Immutable.js structure are currently not supported. You can use Immutable in the rest of your store, but the root object and the `offline` state branch created by Redux Offline currently needs to be vanilla JavaScript objects.
+The `offline` state branch created by Redux Offline needs to be a vanilla JavaScript object.
+If your entire store is immutable you should check out [`redux-offline-immutable-config`](https://github.com/anyjunk/redux-offline-immutable-config) which provides drop-in configurations using immutable counterparts and code examples.
+If you use Immutable in the rest of your store, but the root object, you should not need extra configurations.
 
 [Contributions welcome](#contributing).
-
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "redux-offline",
+  "name": "@anyjunk/redux-offline",
   "version": "1.1.0",
   "description": "Redux Offline-First Architecture",
   "main": "lib/index.js",

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -4,13 +4,17 @@ import effect from './effect';
 import batch from './batch';
 import retry from './retry';
 import discard from './discard';
+import persistAutoRehydrate from './persistAutoRehydrate';
+import offlineStateLens from './offlineStateLens';
 
 export default {
-  rehydrate: true,
+  rehydrate: true, // backward compatibility, TODO remove in the next breaking change version
   persist,
   detectNetwork,
   batch,
   effect,
   retry,
-  discard
+  discard,
+  persistAutoRehydrate,
+  offlineStateLens
 };

--- a/src/defaults/offlineStateLens.js
+++ b/src/defaults/offlineStateLens.js
@@ -1,0 +1,10 @@
+// @flow
+export default (state: any) => {
+  const { offline, ...rest } = state;
+  return {
+    get: offline,
+    set: (offlineState: any) => typeof offlineState === 'undefined'
+      ? rest
+      : { offline: offlineState, ...rest }
+  };
+};

--- a/src/defaults/persistAutoRehydrate.js
+++ b/src/defaults/persistAutoRehydrate.js
@@ -1,0 +1,4 @@
+// @flow
+import { autoRehydrate } from 'redux-persist';
+
+export default autoRehydrate;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 /*global $Shape*/
 import type { Config } from './types';
 import { applyMiddleware, compose } from 'redux';
-import { autoRehydrate } from 'redux-persist';
 import { createOfflineMiddleware } from './middleware';
 import { enhanceReducer } from './updater';
 import { applyDefaults } from './config';
@@ -25,13 +24,13 @@ export const offline = (userConfig: $Shape<Config> = {}) => (createStore: any) =
 
   // wraps userland reducer with a top-level
   // reducer that handles offline state updating
-  const offlineReducer = enhanceReducer(reducer);
+  const offlineReducer = enhanceReducer(reducer, config);
 
   const offlineMiddleware = applyMiddleware(createOfflineMiddleware(config));
 
   // create autoRehydrate enhancer if required
-  const offlineEnhancer = config.persist && config.rehydrate
-    ? compose(offlineMiddleware, enhancer, autoRehydrate())
+  const offlineEnhancer = config.persist && config.rehydrate && config.persistAutoRehydrate
+    ? compose(offlineMiddleware, enhancer, config.persistAutoRehydrate())
     : compose(offlineMiddleware, enhancer);
 
   // create store

--- a/src/types.js
+++ b/src/types.js
@@ -51,7 +51,7 @@ type NetworkCallback = (result: boolean) => void;
 export type Config = {
   batch: (outbox: Outbox) => Outbox,
   detectNetwork: (callback: NetworkCallback) => void,
-  persist: (store: any) => any,
+  persist: (store: any, options: {}, callback: () => void) => any,
   effect: (effect: any, action: OfflineAction) => Promise<*>,
   retry: (action: OfflineAction, retries: number) => ?number,
   discard: (error: any, action: OfflineAction, retries: number) => boolean,

--- a/src/types.js
+++ b/src/types.js
@@ -56,5 +56,7 @@ export type Config = {
   retry: (action: OfflineAction, retries: number) => ?number,
   discard: (error: any, action: OfflineAction, retries: number) => boolean,
   persistOptions: {},
-  persistCallback: (callback: any) => any
+  persistCallback: (callback: any) => any,
+  persistAutoRehydrate: (config: ?{}) => (next: any) => any,
+  offlineStateLens: (state: any) => { get: OfflineState, set: (offlineState: ?OfflineState) => any }
 };

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,7 +1,7 @@
 // @flow
-/* global */
+/*global $Shape*/
 
-import type { OfflineState, OfflineAction, ResultAction } from './types';
+import type { OfflineState, OfflineAction, ResultAction, Config } from './types';
 import {
   OFFLINE_STATUS_CHANGED,
   OFFLINE_SCHEDULE_RETRY,
@@ -91,18 +91,15 @@ const offlineUpdater = function offlineUpdater(
   return state;
 };
 
-export const enhanceReducer = (reducer: any) =>
+export const enhanceReducer = (reducer: any, config: $Shape<Config>) =>
   (state: any, action: any) => {
     let offlineState;
     let restState;
     if (typeof state !== 'undefined') {
-      const { offline, ...rest } = state;
-      offlineState = offline;
-      restState = rest;
+      offlineState = config.offlineStateLens(state).get;
+      restState = config.offlineStateLens(state).set();
     }
 
-    return {
-      ...reducer(restState, action),
-      offline: offlineUpdater(offlineState, action)
-    };
+    return config.offlineStateLens(reducer(restState, action))
+      .set(offlineUpdater(offlineState, action));
   };


### PR DESCRIPTION
This patch allows to use `redux-offline` with a root immutable state.
These are non breaking changes on top of `v2.0.0`

- add config `offlineStateLens`: with state getter and setter and splitter for `offline` state vs rest
- add config `persistAutoRehydrate`: to inject another autoHydration (eg: `redux-persist-immutable`)
- use `offlineStateLens` in the middleware and the enhancer
- add the new flow types for the config
- fix `config.persist` flow type
- update the README.md

Some parts are similar to #54, but unlike it this modification injects your dependency through the config.
An auxiliary npm module providing immutable default configs has been published at: https://www.npmjs.com/package/redux-offline-immutable-config

This code has been written together with @Ashmalech