### PR TITLE
Middleware on Commit/Rollback and Commit/Rollback async action

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
 export const OFFLINE_STATUS_CHANGED = 'Offline/STATUS_CHANGED';
+export const OFFLINE_ASYNC_COMPLETED = 'Offline/ASYNC_COMPLETED';
 export const OFFLINE_SCHEDULE_RETRY = 'Offline/SCHEDULE_RETRY';
 export const OFFLINE_COMPLETE_RETRY = 'Offline/COMPLETE_RETRY';
 export const OFFLINE_SEND = 'Offline/SEND';

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,10 @@ export const offline = (userConfig: $Shape<Config> = {}) => (createStore: any) =
   // reducer that handles offline state updating
   const offlineReducer = enhanceReducer(reducer);
 
-  const offlineMiddleware = applyMiddleware(createOfflineMiddleware(config));
+  const offlineMiddleware = applyMiddleware(
+    ...userConfig.effectResultMiddleware || [],
+    createOfflineMiddleware(config)
+  );
 
   // create autoRehydrate enhancer if required
   const offlineEnhancer = config.persist && config.rehydrate

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -10,7 +10,7 @@ const after = (timeout = 0) => {
 
 const complete = (action: any, success: boolean, payload: {}): ResultAction =>
   typeof action === 'function'
-  ? action.bind(payload)
+  ? action(payload)
   : { ...action, payload, meta: { ...action.meta, success, completed: true } };
 
 const take = (state: AppState, config: Config): Outbox => {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -8,9 +8,10 @@ const after = (timeout = 0) => {
   return new Promise(resolve => setTimeout(resolve, timeout));
 };
 
-const complete = (action: ResultAction, success: boolean, payload: {}): ResultAction => {
-  return { ...action, payload, meta: { ...action.meta, success, completed: true } };
-};
+const complete = (action: any, success: boolean, payload: {}): ResultAction =>
+  typeof action === 'function'
+  ? action.bind(payload)
+  : { ...action, payload, meta: { ...action.meta, success, completed: true } };
 
 const take = (state: AppState, config: Config): Outbox => {
   // batching is optional, for now

--- a/src/types.js
+++ b/src/types.js
@@ -53,6 +53,7 @@ export type Config = {
   detectNetwork: (callback: NetworkCallback) => void,
   persist: (store: any) => any,
   effect: (effect: any, action: OfflineAction) => Promise<*>,
+  effectResultMiddleware: [],
   retry: (action: OfflineAction, retries: number) => ?number,
   discard: (error: any, action: OfflineAction, retries: number) => boolean,
   persistOptions: {},


### PR DESCRIPTION
This add 'effectResultMiddleware' field to options, to apply custom middleware when commit/rollback are dispatched.

This also allow Commit/Rollback to be function, to dynamically compute action from payload instead of precomputed action. This allow transfer logic from reducer to action creator aswell as async action (with redux-thunk).