### PR TITLE
Feature - Custom Logger

### DIFF
--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -5,6 +5,14 @@ import batch from './batch';
 import retry from './retry';
 import discard from './discard';
 
+const noop = () => {};
+const loggerStub = {
+  log: noop,
+  warn: noop,
+  error: noop,
+  debug: noop
+};
+
 export default {
   rehydrate: true,
   persist,
@@ -12,5 +20,6 @@ export default {
   batch,
   effect,
   retry,
-  discard
+  discard,
+  logger: loggerStub
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,10 +18,11 @@ export const offline = (userConfig: $Shape<Config> = {}) => (createStore: any) =
   preloadedState: any,
   enhancer: any = x => x
 ) => {
-  console.log('user config', userConfig);
   const config = applyDefaults(userConfig);
+  const { logger } = config;
 
-  console.log('Creating offline store', config);
+  logger.log('user config', userConfig);
+  logger.log('Creating offline store', config);
 
   // wraps userland reducer with a top-level
   // reducer that handles offline state updating
@@ -51,3 +52,4 @@ export const offline = (userConfig: $Shape<Config> = {}) => (createStore: any) =
 
   return store;
 };
+

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -22,6 +22,7 @@ const take = (state: AppState, config: Config): Outbox => {
 };
 
 const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
+  const { logger } = config;
   const metadata = action.meta.offline;
   dispatch(busy(true));
   return config
@@ -30,15 +31,15 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
     .catch(error => {
       // discard
       if (config.discard(error, action, retries)) {
-        console.log('Discarding action', action.type);
+        logger.log('Discarding action', action.type);
         return dispatch(complete(metadata.rollback, false, error));
       }
       const delay = config.retry(action, retries);
       if (delay != null) {
-        console.log('Retrying action', action.type, 'with delay', delay);
+        logger.log('Retrying action', action.type, 'with delay', delay);
         return dispatch(scheduleRetry(delay));
       } else {
-        console.log('Discarding action', action.type, 'because retry did not return a delay');
+        logger.log('Discarding action', action.type, 'because retry did not return a delay');
         return dispatch(complete(metadata.rollback, false, error));
       }
     });

--- a/src/types.js
+++ b/src/types.js
@@ -56,5 +56,11 @@ export type Config = {
   retry: (action: OfflineAction, retries: number) => ?number,
   discard: (error: any, action: OfflineAction, retries: number) => boolean,
   persistOptions: {},
-  persistCallback: (callback: any) => any
+  persistCallback: (callback: any) => any,
+  logger: {
+    debug: Function,
+    info: Function,
+    log: Function,
+    warn: Function,
+  },
 };


### PR DESCRIPTION
I found the console.log's default output quite noisy, especially in tests. I've added support to be able to pass a custom logger with a stubbed fallback. This means you can suppress the logs by not passing anything, pass `console` if you want existing behaviour or pass your own custom logger which is useful if you use a logging service.

Happy to change the pattern of how it's done if it doesn't fit the project style.