### PR TITLE
Use completeRetry() correctly

### DIFF
--- a/src/__tests__/middleware.js
+++ b/src/__tests__/middleware.js
@@ -78,8 +78,9 @@ describe("on OFFLINE_SCHEDULE_RETRY", () => {
     jest.runTimersToTime(delay);
 
     expect.assertions(1);
+    const offlineAction = store.getState().offline.outbox[0];
     return Promise.resolve().then(() =>
-      expect(store.dispatch).toBeCalledWith(completeRetry())
+      expect(store.dispatch).toBeCalledWith(completeRetry(offlineAction))
     );
   });
 });

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -64,7 +64,8 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (next
   }
 
   if (action.type === OFFLINE_SCHEDULE_RETRY) {
-    after(action.payload.delay).then(() => store.dispatch(completeRetry()));
+    after(action.payload.delay).then(() => { store.dispatch(completeRetry(offlineAction));
+    });
   }
 
   if (action.type === OFFLINE_SEND && offlineAction && !state.offline.busy) {


### PR DESCRIPTION
`completeRetry()` expects an action but none was provided.

Alternatively we could change the action creator to match usage.