### PR TITLE
Alternative API

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,21 @@ If you use Immutable in the rest of your store, but the root object, you should 
 
 [Contributions welcome](#contributing).
 
+#### Choose where the offline middleware is added
+
+By default, the offline middleware is inserted right before the offline store enhancer as part of its own middleware chain. If you want more control over where the middleware is inserted, consider using the alternative api, `createOffline()`.
+
+```js
+import { createOffline } from "@redux-offline/redux-offline";
+const { middleware, enhanceReducer, enhanceStore } = createOffline(config);
+const store = createStore(
+  enhanceReducer(rootReducer),
+  initialStore,
+  compose(applyMiddleware(middleware), enhanceStore)
+);
+```
+
+
 ## Contributing
 
 Improvements and additions welcome. For large changes, please submit a discussion issue before jumping to coding; we'd hate you to waste the effort.

--- a/examples/basic/client/package.json
+++ b/examples/basic/client/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "alternative": "REACT_APP_OFFLINE_API=alternative react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,8 +1,8 @@
-import { compose, createStore } from "redux";
+import { applyMiddleware, compose, createStore } from "redux";
 import { KEY_PREFIX } from "redux-persist/lib/constants"
 import { AsyncNodeStorage } from "redux-persist-node-storage";
 import instrument from "redux-devtools-instrument";
-import { offline } from "../index";
+import { createOffline, offline } from "../index";
 import { applyDefaults } from "../config";
 
 const storage = new AsyncNodeStorage("/tmp/storageDir");
@@ -35,10 +35,22 @@ function defaultReducer(state = {
   return state;
 }
 
-test("creates storeEnhancer", () => {
+test("offline() creates storeEnhancer", () => {
   const storeEnhancer = offline(defaultConfig);
 
   const store = storeEnhancer(createStore)(defaultReducer);
+  expect(store.dispatch).toEqual(expect.any(Function));
+  expect(store.getState).toEqual(expect.any(Function));
+});
+
+test("createOffline() creates storeEnhancer", () => {
+  const { middleware, enhanceReducer, enhanceStore } =
+    createOffline(defaultConfig);
+  const reducer = enhanceReducer(defaultReducer);
+  const store = createStore(reducer, compose(
+    applyMiddleware(middleware),
+    enhanceStore
+  ));
   expect(store.dispatch).toEqual(expect.any(Function));
   expect(store.getState).toEqual(expect.any(Function));
 });


### PR DESCRIPTION
Currently, Redux Offline decides where to insert the offline middleware. This is unnecessary and can sometimes cause difficulties with other libraries, as in #16.

This PR introduces an alternative API, for when users need a bit more flexibility.

Other changes are possible. The reducer could be exposed instead of `enhanceReducer()`. And there is really no reason to set up Redux Persist for the user: it just forces them to use a particular version of the library. But I figured this is enough code to start a discussion.

Not immediately important, but something to consider.