### PR TITLE
Support HMR by overriding `store.replaceReducer()`

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -43,6 +43,14 @@ test("creates storeEnhancer", () => {
   expect(store.getState).toEqual(expect.any(Function));
 });
 
+// see https://github.com/redux-offline/redux-offline/issues/31
+test("supports HMR by overriding `replaceReducer()`", () => {
+  const store = offline(defaultConfig)(createStore)(defaultReducer);
+  store.replaceReducer(defaultReducer);
+  store.dispatch({ type: "SOME_ACTION" });
+  expect(store.getState()).toHaveProperty("offline");
+});
+
 // see https://github.com/redux-offline/redux-offline/issues/4
 test("restores offline outbox when rehydrates", () => {
   const actions = [{

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,11 @@ export const offline = (userConfig: $Shape<Config> = {}) => (
     enhancer
   );
 
+  const baseReplaceReducer = store.replaceReducer.bind(store);
+  store.replaceReducer = function replaceReducer(nextReducer) {
+    return baseReplaceReducer(enhanceReducer(nextReducer, config));
+  };
+
   // launch store persistor
   if (config.persist) {
     persistor = config.persist(


### PR DESCRIPTION
In order to support Hot Module Replacement you need to enhance the reducer each time `store.replaceReducer()` is called.

see #31 