### PR TITLE
Immutable js root state

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,13 +298,16 @@ Redux Offline supports the following configuration properties:
 ```js
 export type Config = {
   detectNetwork: (callback: NetworkCallback) => void,
-  persist: (store: any) => any,
   effect: (effect: any, action: OfflineAction) => Promise<*>,
   retry: (action: OfflineAction, retries: number) => ?number,
   discard: (error: any, action: OfflineAction, retries: number) => boolean,
-  persistOptions: {},
   defaultCommit: { type: string },
-  defaultRollback: { type: string }
+  defaultRollback: { type: string },
+  persist: (store: any) => any,
+  persistOptions: {},
+  persistCallback: (callback: any) => any,
+  persistAutoRehydrate: (config: ?{}) => (next: any) => any,
+  offlineStateLens: (state: any) => { get: OfflineState, set: (offlineState: ?OfflineState) => any }
 };
 ```
 
@@ -402,6 +405,15 @@ const config = {
 };
 ```
 
+You can pass your persistAutoRehydrate method. For example in this way you can add a logger to the persistor.
+```js
+import { autoRehydrate } from 'redux-persist';
+
+const config = {
+  persistAutoRehydrate: () => autoRehydrate({log: true})
+};
+```
+
 If you want to replace redux-persist entirely **(not recommended)**, you can override `config.persist`. The function receives the store instance as a first parameter, and is responsible for setting any subscribers to listen for store changes to persist it.
 ```js
 const config = {
@@ -465,10 +477,11 @@ Background sync is not yet supported. Coming soon.
 
 #### Use an [Immutable](https://facebook.github.io/immutable-js/) store
 
-Stores that implement the entire store as an Immutable.js structure are currently not supported. You can use Immutable in the rest of your store, but the root object and the `offline` state branch created by Redux Offline currently needs to be vanilla JavaScript objects.
+The `offline` state branch created by Redux Offline needs to be a vanilla JavaScript object.
+If your entire store is immutable you should check out [`redux-offline-immutable-config`](https://github.com/anyjunk/redux-offline-immutable-config) which provides drop-in configurations using immutable counterparts and code examples.
+If you use Immutable in the rest of your store, but the root object, you should not need extra configurations.
 
 [Contributions welcome](#contributing).
-
 
 ## Contributing
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -7,6 +7,25 @@ import { applyDefaults } from "../config";
 
 beforeEach(() => storage.removeItem(storageKey, noop) );
 
+const defaultOfflineState = {
+  busy: false,
+  lastTransaction: 0,
+  online: true,
+  outbox: [],
+  receipts: [],
+  retryToken: 0,
+  retryCount: 0,
+  retryScheduled: false,
+  netInfo: {
+    isConnectionExpensive: null,
+    reach: 'NONE'
+  }
+};
+
+const state = {
+  offline: defaultOfflineState
+};
+
 test("creates storeEnhancer", () => {
   const reducer = noop;
   const storeEnhancer = offline(defaultConfig);
@@ -55,4 +74,6 @@ test("works with devtools store enhancer", () => {
 const storage = new AsyncNodeStorage("/tmp/storageDir");
 const defaultConfig = applyDefaults({ persistOptions: { storage } });
 const storageKey = `${KEY_PREFIX}offline`;
-function noop() {}
+function noop() {
+  return state;
+}

--- a/src/__tests__/middleware.js
+++ b/src/__tests__/middleware.js
@@ -3,6 +3,8 @@ import { completeRetry, scheduleRetry } from '../actions';
 import { OFFLINE_SEND } from '../constants';
 import send from '../send';
 
+import offlineStateLens from '../defaults/offlineStateLens'
+
 const offlineAction = {
   type: 'OFFLINE_ACTION_REQUEST',
   meta: {
@@ -41,7 +43,8 @@ function setup(offlineState = {}) {
       batch: jest.fn(outbox => outbox.slice(0, 1)),
       effect: jest.fn(),
       retry: jest.fn(),
-      discard: jest.fn()
+      discard: jest.fn(),
+      offlineStateLens,
     },
     store: {
       getState: jest.fn(() => state),

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -5,14 +5,18 @@ import retry from './retry';
 import discard from './discard';
 import defaultCommit from './defaultCommit';
 import defaultRollback from './defaultRollback';
+import persistAutoRehydrate from './persistAutoRehydrate';
+import offlineStateLens from './offlineStateLens';
 
 export default {
-  rehydrate: true,
+  rehydrate: true, // backward compatibility, TODO remove in the next breaking change version
   persist,
   detectNetwork,
   effect,
   retry,
   discard,
   defaultCommit,
-  defaultRollback
+  defaultRollback,
+  persistAutoRehydrate,
+  offlineStateLens
 };

--- a/src/defaults/offlineStateLens.js
+++ b/src/defaults/offlineStateLens.js
@@ -1,0 +1,11 @@
+// @flow
+export default (state: any) => {
+  const { offline, ...rest } = state;
+  return {
+    get: offline,
+    set: (offlineState: any) =>
+      typeof offlineState === 'undefined'
+        ? rest
+        : { offline: offlineState, ...rest }
+  };
+};

--- a/src/defaults/persistAutoRehydrate.js
+++ b/src/defaults/persistAutoRehydrate.js
@@ -1,0 +1,4 @@
+// @flow
+import { autoRehydrate } from 'redux-persist';
+
+export default autoRehydrate;

--- a/src/index.js
+++ b/src/index.js
@@ -46,8 +46,8 @@ export const offline = (userConfig: $Shape<Config> = {}) => (
   // create autoRehydrate enhancer if required
   const offlineEnhancer =
     config.persist && config.rehydrate && config.persistAutoRehydrate
-      ? compose(offlineMiddleware, enhancer, config.persistAutoRehydrate())
-      : compose(offlineMiddleware, enhancer);
+      ? compose(offlineMiddleware, config.persistAutoRehydrate())
+      : offlineMiddleware;
 
   // create store
   const store = offlineEnhancer(createStore)(

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 // @flow
 /* global $Shape */
 import { applyMiddleware, compose } from 'redux';
-import { autoRehydrate } from 'redux-persist';
 import type { Config } from './types';
 import { createOfflineMiddleware } from './middleware';
 import { enhanceReducer } from './updater';
@@ -40,15 +39,15 @@ export const offline = (userConfig: $Shape<Config> = {}) => (
 
   // wraps userland reducer with a top-level
   // reducer that handles offline state updating
-  const offlineReducer = enhanceReducer(reducer);
+  const offlineReducer = enhanceReducer(reducer, config);
 
   const offlineMiddleware = applyMiddleware(createOfflineMiddleware(config));
 
   // create autoRehydrate enhancer if required
   const offlineEnhancer =
-    config.persist && config.rehydrate
-      ? compose(offlineMiddleware, autoRehydrate())
-      : offlineMiddleware;
+    config.persist && config.rehydrate && config.persistAutoRehydrate
+      ? compose(offlineMiddleware, enhancer, config.persistAutoRehydrate())
+      : compose(offlineMiddleware, enhancer);
 
   // create store
   const store = offlineEnhancer(createStore)(

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -16,17 +16,18 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (
 
   // find any actions to send, if any
   const state: AppState = store.getState();
-  const offlineAction = state.offline.outbox[0];
+  const offline = config.offlineStateLens(state).get;
+  const offlineAction = offline.outbox[0];
 
   // if the are any actions in the queue that we are not
   // yet processing, send those actions
   if (
     offlineAction &&
-    !state.offline.busy &&
-    !state.offline.retryScheduled &&
-    state.offline.online
+    !offline.busy &&
+    !offline.retryScheduled &&
+    offline.online
   ) {
-    send(offlineAction, store.dispatch, config, state.offline.retryCount);
+    send(offlineAction, store.dispatch, config, offline.retryCount);
   }
 
   if (action.type === OFFLINE_SCHEDULE_RETRY) {
@@ -35,8 +36,9 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (
     });
   }
 
-  if (action.type === OFFLINE_SEND && offlineAction && !state.offline.busy) {
-    send(offlineAction, store.dispatch, config, state.offline.retryCount);
+  if (action.type === OFFLINE_SEND && offlineAction && !offline.busy) {
+    send(offlineAction, store.dispatch, config, offline.retryCount);
   }
+
   return result;
 };

--- a/src/types.js
+++ b/src/types.js
@@ -42,12 +42,16 @@ type NetworkCallback = (result: boolean) => void;
 
 export type Config = {
   detectNetwork: (callback: NetworkCallback) => void,
-  persist: (store: any) => any,
+  persist: (store: any, options: {}, callback: () => void) => any,
   effect: (effect: any, action: OfflineAction) => Promise<*>,
   retry: (action: OfflineAction, retries: number) => ?number,
   discard: (error: any, action: OfflineAction, retries: number) => boolean,
   persistOptions: {},
   persistCallback: (callback: any) => any,
   defaultCommit: { type: string },
-  defaultRollback: { type: string }
+  defaultRollback: { type: string },
+  persistAutoRehydrate: (config: ?{}) => (next: any) => any,
+  offlineStateLens: (
+    state: any
+  ) => { get: OfflineState, set: (offlineState: ?OfflineState) => any }
 };

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,7 +1,12 @@
 // @flow
-/* global */
+/* global $Shape */
 
-import type { OfflineState, OfflineAction, ResultAction } from './types';
+import type {
+  OfflineState,
+  OfflineAction,
+  ResultAction,
+  Config
+} from './types';
 import {
   OFFLINE_STATUS_CHANGED,
   OFFLINE_SCHEDULE_RETRY,
@@ -118,17 +123,18 @@ const offlineUpdater = function offlineUpdater(
   return state;
 };
 
-export const enhanceReducer = (reducer: any) => (state: any, action: any) => {
+export const enhanceReducer = (reducer: any, config: $Shape<Config>) => (
+  state: any,
+  action: any
+) => {
   let offlineState;
   let restState;
   if (typeof state !== 'undefined') {
-    const { offline, ...rest } = state;
-    offlineState = offline;
-    restState = rest;
+    offlineState = config.offlineStateLens(state).get;
+    restState = config.offlineStateLens(state).set();
   }
 
-  return {
-    ...reducer(restState, action),
-    offline: offlineUpdater(offlineState, action)
-  };
+  return config
+    .offlineStateLens(reducer(restState, action))
+    .set(offlineUpdater(offlineState, action));
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,20 +34,20 @@ acorn@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
 
-ajv-keywords@^1.0.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+ajv-keywords@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.0.tgz#a296e17f7bfae7c1ce4f7e0de53d29cb32162df0"
 
-ajv@^4.7.0, ajv@^4.9.1:
+ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.2.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
+ajv@^5.2.0, ajv@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -70,9 +70,9 @@ ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
-ansi-escapes@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
+ansi-escapes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -1065,6 +1065,12 @@ debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+debug@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1171,8 +1177,8 @@ escodegen@^1.6.1:
     source-map "~0.2.0"
 
 eslint-config-airbnb-base@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.0.0.tgz#99063aaef4b8698083481a00e165cbe15e82d615"
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.0.1.tgz#abaca7b4536faa7e094add5a9801970fefdd39a4"
   dependencies:
     eslint-restricted-globals "^0.1.1"
 
@@ -1234,18 +1240,18 @@ eslint-scope@^3.7.1:
     estraverse "^4.1.1"
 
 eslint@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.6.1.tgz#ddc7fc7fd70bf93205b0b3449bb16a1e9e7d4950"
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.7.2.tgz#ff6f5f5193848a27ee9b627be3e73fb9cb5e662e"
   dependencies:
     ajv "^5.2.0"
     babel-code-frame "^6.22.0"
     chalk "^2.1.0"
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
-    debug "^2.6.8"
+    debug "^3.0.1"
     doctrine "^2.0.0"
     eslint-scope "^3.7.1"
-    espree "^3.5.0"
+    espree "^3.5.1"
     esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
@@ -1266,7 +1272,7 @@ eslint@^4.6.1:
     natural-compare "^1.4.0"
     optionator "^0.8.2"
     path-is-inside "^1.0.2"
-    pluralize "^4.0.0"
+    pluralize "^7.0.0"
     progress "^2.0.0"
     require-uncached "^1.0.3"
     semver "^5.3.0"
@@ -1275,9 +1281,9 @@ eslint@^4.6.1:
     table "^4.0.1"
     text-table "~0.2.0"
 
-espree@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.0.tgz#98358625bdd055861ea27e2867ea729faf463d8d"
+espree@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
   dependencies:
     acorn "^5.1.1"
     acorn-jsx "^3.0.0"
@@ -1338,12 +1344,12 @@ extend@~3.0.0:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
 external-editor@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.5.tgz#52c249a3981b9ba187c7cacf5beb50bf1d91a6bc"
   dependencies:
     iconv-lite "^0.4.17"
     jschardet "^1.4.2"
-    tmp "^0.0.31"
+    tmp "^0.0.33"
 
 extglob@^0.3.1:
   version "0.3.2"
@@ -1706,10 +1712,10 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
 inquirer@^3.0.6:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.3.tgz#1c7b1731cf77b934ec47d22c9ac5aa8fe7fbe095"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:
-    ansi-escapes "^2.0.0"
+    ansi-escapes "^3.0.0"
     chalk "^2.0.0"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
@@ -2156,9 +2162,16 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.7.0, js-yaml@^3.9.1:
+js-yaml@^3.7.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.9.1:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -2305,7 +2318,7 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2542,7 +2555,7 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -2650,9 +2663,9 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-pluralize@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -3037,9 +3050,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slice-ansi@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+slice-ansi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
 
 slide@^1.1.5:
   version "1.1.6"
@@ -3119,7 +3134,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.0:
+string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -3187,15 +3202,15 @@ symbol-tree@^3.2.1:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
 table@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-4.0.1.tgz#a8116c133fac2c61f4a420ab6cdf5c4d61f0e435"
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
   dependencies:
-    ajv "^4.7.0"
-    ajv-keywords "^1.0.0"
-    chalk "^1.1.1"
-    lodash "^4.0.0"
-    slice-ansi "0.0.4"
-    string-width "^2.0.0"
+    ajv "^5.2.3"
+    ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
 
 tar-pack@^3.4.0:
   version "3.4.0"
@@ -3240,11 +3255,11 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-tmp@^0.0.31:
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   dependencies:
-    os-tmpdir "~1.0.1"
+    os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
Addresses issue #37 

This patch allows to use `redux-offline` with a root immutable state.
These are non breaking changes on top of `v2.1.0`

- added config `offlineStateLens`: with state getter and setter and splitter for `offline` state vs rest
- added config `persistAutoRehydrate`: to inject another autoHydration (eg: `redux-persist-immutable`)
- used `offlineStateLens` in the middleware and the enhancer
- added the new flow types for the config
- fixed `config.persist` flow type
- updated the README.md

An auxiliary npm module providing immutable default configs has been published at: https://www.npmjs.com/package/redux-offline-immutable-config

This code has been written together with @Ashmalech