### PR TITLE
Fix failing test

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -37,7 +37,8 @@ test("creates storeEnhancer", () => {
 
 // see https://github.com/redux-offline/redux-offline/issues/4
 test("restores offline outbox when rehydrates", () => {
-  const actions = [{ type: "SOME_OFFLINE_ACTION" }];
+  const meta = { offline: { effect: {} } };
+  const actions = [{ type: "SOME_OFFLINE_ACTION", meta }];
   storage.setItem(
     storageKey,
     JSON.stringify({ outbox: actions }),

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -5,46 +5,55 @@ import instrument from "redux-devtools-instrument";
 import { offline } from "../index";
 import { applyDefaults } from "../config";
 
+const storage = new AsyncNodeStorage("/tmp/storageDir");
+const storageKey = `${KEY_PREFIX}offline`;
+function noop() {}
+
 beforeEach(() => storage.removeItem(storageKey, noop) );
 
-const defaultOfflineState = {
-  busy: false,
-  lastTransaction: 0,
-  online: true,
-  outbox: [],
-  receipts: [],
-  retryToken: 0,
-  retryCount: 0,
-  retryScheduled: false,
-  netInfo: {
-    isConnectionExpensive: null,
-    reach: 'NONE'
-  }
-};
+const defaultConfig = applyDefaults({
+  effect: jest.fn(() => Promise.resolve()),
+  persistOptions: { storage }
+});
 
-const state = {
-  offline: defaultOfflineState
-};
+function defaultReducer(state = {
+  offline: {
+    busy: false,
+    lastTransaction: 0,
+    online: true,
+    outbox: [],
+    receipts: [],
+    retryToken: 0,
+    retryCount: 0,
+    retryScheduled: false,
+    netInfo: {
+      isConnectionExpensive: null,
+      reach: 'NONE'
+    }
+  }
+}) {
+  return state;
+}
 
 test("creates storeEnhancer", () => {
-  const reducer = noop;
   const storeEnhancer = offline(defaultConfig);
 
-  const store = storeEnhancer(createStore)(reducer);
+  const store = storeEnhancer(createStore)(defaultReducer);
   expect(store.dispatch).toEqual(expect.any(Function));
   expect(store.getState).toEqual(expect.any(Function));
 });
 
 // see https://github.com/redux-offline/redux-offline/issues/4
 test("restores offline outbox when rehydrates", () => {
-  const meta = { offline: { effect: {} } };
-  const actions = [{ type: "SOME_OFFLINE_ACTION", meta }];
+  const actions = [{
+    type: "SOME_OFFLINE_ACTION",
+    meta: { offline: { effect: {} } }
+  }];
   storage.setItem(
     storageKey,
     JSON.stringify({ outbox: actions }),
     noop
   );
-  const reducer = noop;
 
   expect.assertions(1);
   return new Promise(resolve => {
@@ -55,26 +64,19 @@ test("restores offline outbox when rehydrates", () => {
         expect(outbox).toEqual(actions);
         resolve();
       }
-    })(createStore)(reducer);
+    })(createStore)(defaultReducer);
   });
 });
 
 // see https://github.com/jevakallio/redux-offline/pull/91
 test("works with devtools store enhancer", () => {
   const monitorReducer = state => state;
-  const devtoolsEnhancer = instrument(monitorReducer);
-  const offlineEnhancer = offline(defaultConfig);
-  const reducer = noop;
-  const store = createStore(reducer, compose(offlineEnhancer, devtoolsEnhancer));
+  const store = createStore(
+    defaultReducer,
+    compose(offline(defaultConfig), instrument(monitorReducer))
+  );
 
   expect(() => {
     store.dispatch({ type: "SOME_ACTION" });
   }).not.toThrow();
 });
-
-const storage = new AsyncNodeStorage("/tmp/storageDir");
-const defaultConfig = applyDefaults({ persistOptions: { storage } });
-const storageKey = `${KEY_PREFIX}offline`;
-function noop() {
-  return state;
-}


### PR DESCRIPTION
There was a test that failed sporadically. It should have been failing all the time, not because the underlying feature was broken, but because I forgot to add necessary meta information to an offline action being used in the test.

Both the failing and sporadically parts have been fixed. I took the opportunity to make some other improvements. Specifically not reusing the default state in case someone mutated it and separating noop from the default reducer, which had been merged for some reason.

I will leave this up for a few days in case anyone wants to take a look before I merge it.