### PR TITLE
Updated deprecated NetInfo usage

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -28,7 +28,7 @@ function defaultReducer(state = {
     retryScheduled: false,
     netInfo: {
       isConnectionExpensive: null,
-      reach: 'NONE'
+      reach: 'none'
     }
   }
 }) {

--- a/src/defaults/detectNetwork.native.js
+++ b/src/defaults/detectNetwork.native.js
@@ -121,4 +121,5 @@ class DetectNetwork {
 }
 
 const isLegacy = typeof NetInfo.getConnectionInfo === 'undefined';
-export default callback => (isLegacy ? LegacyDetectNetwork(callback) : DetectNetwork(callback))
+export default callback =>
+  isLegacy ? LegacyDetectNetwork(callback) : DetectNetwork(callback);

--- a/src/defaults/detectNetwork.native.js
+++ b/src/defaults/detectNetwork.native.js
@@ -15,9 +15,8 @@ class DetectNetwork {
   /**
    * Check props for changes
    * @param {string} reach - connection reachability.
-   *     - iOS: [none, wifi, cell, unknown]
-   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
-   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
+   *     - Cross-platform: [none, wifi, cellular, unknown]
+   *     - Android: [bluetooth, ethernet, wimax]
    * @returns {boolean} - Whether the connection reachability or the connection props have changed
    * @private
    */
@@ -33,9 +32,8 @@ class DetectNetwork {
   /**
    * Sets the connection reachability prop
    * @param {string} reach - connection reachability.
-   *     - iOS: [none, wifi, cell, unknown]
-   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
-   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
+   *     - Cross-platform: [none, wifi, cellular, unknown]
+   *     - Android: [bluetooth, ethernet, wimax]
    * @returns {void}
    * @private
    */
@@ -46,13 +44,12 @@ class DetectNetwork {
   /**
    * Gets the isConnected prop depending on the connection reachability's value
    * @param {string} reach - connection reachability.
-   *     - iOS: [none, wifi, cell, unknown]
-   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
-   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
+   *     - Cross-platform: [none, wifi, cellular, unknown]
+   *     - Android: [bluetooth, ethernet, wimax]
    * @returns {void}
    * @private
    */
-  _getConnection = reach => reach !== 'NONE' && reach !== 'UNKNOWN';
+  _getConnection = reach => reach !== 'none' && reach !== 'unknown';
   /**
    * Sets the isConnectionExpensive prop
    * @returns {Promise.<void>} Resolves to true if connection is expensive,
@@ -74,22 +71,20 @@ class DetectNetwork {
    * @private
    */
   _init = async () => {
-    const reach = await NetInfo.fetch();
-    this._update(reach);
+    const connectionInfo = await NetInfo.getConnectionInfo();
+    this._update(connectionInfo.type);
   };
   /**
    * Check changes on props and store and dispatch if neccesary
    * @param {string} reach - connection reachability.
-   *     - iOS: [none, wifi, cell, unknown]
-   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
-   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
+   *     - Cross-platform: [none, wifi, cellular, unknown]
+   *     - Android: [bluetooth, ethernet, wimax]
    * @returns {void}
    * @private
    */
   _update = reach => {
-    const normalizedReach = reach.toUpperCase();
-    if (this._hasChanged(normalizedReach)) {
-      this._setReach(normalizedReach);
+    if (this._hasChanged(reach)) {
+      this._setReach(reach);
       this._dispatch();
     }
   };
@@ -100,8 +95,8 @@ class DetectNetwork {
    * @private
    */
   _addListeners() {
-    NetInfo.addEventListener('change', reach => {
-      this._update(reach);
+    NetInfo.addEventListener('connectionChange', connectionInfo => {
+      this._update(connectionInfo.type);
     });
     AppState.addEventListener('change', this._init);
   }

--- a/src/defaults/detectNetwork.native.legacy.js
+++ b/src/defaults/detectNetwork.native.legacy.js
@@ -1,8 +1,7 @@
 /* eslint no-underscore-dangle: 0 */
 import { AppState, NetInfo } from 'react-native'; // eslint-disable-line
-import LegacyDetectNetwork from './detectNetwork.native.legacy';
 
-class DetectNetwork {
+class LegacyDetectNetwork {
   constructor(callback) {
     this._reach = null;
     this._isConnected = null;
@@ -16,8 +15,9 @@ class DetectNetwork {
   /**
    * Check props for changes
    * @param {string} reach - connection reachability.
-   *     - Cross-platform: [none, wifi, cellular, unknown]
-   *     - Android: [bluetooth, ethernet, wimax]
+   *     - iOS: [none, wifi, cell, unknown]
+   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
+   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
    * @returns {boolean} - Whether the connection reachability or the connection props have changed
    * @private
    */
@@ -33,8 +33,9 @@ class DetectNetwork {
   /**
    * Sets the connection reachability prop
    * @param {string} reach - connection reachability.
-   *     - Cross-platform: [none, wifi, cellular, unknown]
-   *     - Android: [bluetooth, ethernet, wimax]
+   *     - iOS: [none, wifi, cell, unknown]
+   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
+   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
    * @returns {void}
    * @private
    */
@@ -45,12 +46,13 @@ class DetectNetwork {
   /**
    * Gets the isConnected prop depending on the connection reachability's value
    * @param {string} reach - connection reachability.
-   *     - Cross-platform: [none, wifi, cellular, unknown]
-   *     - Android: [bluetooth, ethernet, wimax]
+   *     - iOS: [none, wifi, cell, unknown]
+   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
+   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
    * @returns {void}
    * @private
    */
-  _getConnection = reach => reach !== 'none' && reach !== 'unknown';
+  _getConnection = reach => reach !== 'NONE' && reach !== 'UNKNOWN';
   /**
    * Sets the isConnectionExpensive prop
    * @returns {Promise.<void>} Resolves to true if connection is expensive,
@@ -72,20 +74,22 @@ class DetectNetwork {
    * @private
    */
   _init = async () => {
-    const connectionInfo = await NetInfo.getConnectionInfo();
-    this._update(connectionInfo.type);
+    const reach = await NetInfo.fetch();
+    this._update(reach);
   };
   /**
    * Check changes on props and store and dispatch if neccesary
    * @param {string} reach - connection reachability.
-   *     - Cross-platform: [none, wifi, cellular, unknown]
-   *     - Android: [bluetooth, ethernet, wimax]
+   *     - iOS: [none, wifi, cell, unknown]
+   *     - Android: [NONE, BLUETOOTH, DUMMY, ETHERNET, MOBILE, MOBILE_DUN, MOBILE_HIPRI,
+   *                MOBILE_MMS, MOBILE_SUPL, VPN, WIFI, WIMAX, UNKNOWN]
    * @returns {void}
    * @private
    */
   _update = reach => {
-    if (this._hasChanged(reach)) {
-      this._setReach(reach);
+    const normalizedReach = reach.toUpperCase();
+    if (this._hasChanged(normalizedReach)) {
+      this._setReach(normalizedReach);
       this._dispatch();
     }
   };
@@ -96,8 +100,8 @@ class DetectNetwork {
    * @private
    */
   _addListeners() {
-    NetInfo.addEventListener('connectionChange', connectionInfo => {
-      this._update(connectionInfo.type);
+    NetInfo.addEventListener('change', reach => {
+      this._update(reach);
     });
     AppState.addEventListener('change', this._init);
   }
@@ -120,5 +124,4 @@ class DetectNetwork {
   };
 }
 
-const isLegacy = typeof NetInfo.getConnectionInfo === 'undefined';
-export default callback => (isLegacy ? LegacyDetectNetwork(callback) : DetectNetwork(callback))
+export default LegacyDetectNetwork;


### PR DESCRIPTION
Fixes #39.

- `fetch()` -> `getConnectionInfo()`
- `change` -> `connectionChange`
- updated reach values