### PR TITLE
Allow to use Promises on `discard` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ export type Config = {
   detectNetwork: (callback: NetworkCallback) => void,
   effect: (effect: any, action: OfflineAction) => Promise<*>,
   retry: (action: OfflineAction, retries: number) => ?number,
-  discard: (error: any, action: OfflineAction, retries: number) => boolean,
+  discard: (error: any, action: OfflineAction, retries: number) => boolean|Promise<boolean>,
   defaultCommit: { type: string },
   defaultRollback: { type: string },
   persist: (store: any) => any,
@@ -446,7 +446,14 @@ const config = {
 }
 ```
 
-The method receives the Error returned by the effect reconciler, the action being processed, and a number representing how many times the action has been retried. If the method returns `true`, the action will be discarded; `false`, and it will be retried. The full signature of the method is `(error: any, action: OfflineAction, retries: number) => boolean`.
+The method receives the Error returned by the effect reconciler, the action
+being processed, and a number representing how many times the action has been
+retried. If the method returns `true`, the action will be discarded; `false`,
+and it will be retried. The full signature of the method is `(error: any,
+action: OfflineAction, retries: number) => boolean`. Alternatively, you can
+return a Promise object that resolve to a boolean, allowing you to detect when
+to discard asynchronously (for example, doing a request to a server to refresh a
+token and try again).
 
 #### Change how network requests are retried
 

--- a/README.md
+++ b/README.md
@@ -446,14 +446,7 @@ const config = {
 }
 ```
 
-The method receives the Error returned by the effect reconciler, the action
-being processed, and a number representing how many times the action has been
-retried. If the method returns `true`, the action will be discarded; `false`,
-and it will be retried. The full signature of the method is `(error: any,
-action: OfflineAction, retries: number) => boolean`. Alternatively, you can
-return a Promise object that resolve to a boolean, allowing you to detect when
-to discard asynchronously (for example, doing a request to a server to refresh a
-token and try again).
+The method receives the Error returned by the effect reconciler, the action being processed, and a number representing how many times the action has been retried. If the method returns `true`, the action will be discarded; `false`, and it will be retried. The full signature of the method is `(error: any, action: OfflineAction, retries: number) => boolean`. Alternatively, you can return a Promise object that resolve to a boolean, allowing you to detect when to discard asynchronously (for example, doing a request to a server to refresh a token and try again).
 
 #### Change how network requests are retried
 

--- a/src/__tests__/send.js
+++ b/src/__tests__/send.js
@@ -85,6 +85,34 @@ describe('when request fails', () => {
       expect(dispatch).toBeCalledWith(expect.objectContaining(completedMeta));
     });
   });
+
+  test('dispatches complete action with promised discard', () => {
+    const effect = () => Promise.reject();
+    const discard = () => Promise.resolve(true);
+    const { action, config, dispatch } = setup({ effect, discard });
+    const promise = send(action, dispatch, config);
+
+    const { rollback } = action.meta.offline;
+    expect.assertions(2);
+    return promise.then(() => {
+      expect(dispatch).toBeCalledWith(expect.objectContaining(rollback));
+      expect(dispatch).toBeCalledWith(expect.objectContaining(completedMeta));
+    });
+  });
+
+  test('dispatches complete action when discard throw an exception', () => {
+    const effect = () => Promise.reject();
+    const discard = () => {throw new Error};
+    const { action, config, dispatch } = setup({ effect, discard });
+    const promise = send(action, dispatch, config);
+
+    const { rollback } = action.meta.offline;
+    expect.assertions(2);
+    return promise.then(() => {
+      expect(dispatch).toBeCalledWith(expect.objectContaining(rollback));
+      expect(dispatch).toBeCalledWith(expect.objectContaining(completedMeta));
+    });
+  });
 });
 
 describe('when request succeeds and commit is undefined', () => {

--- a/src/send.js
+++ b/src/send.js
@@ -35,11 +35,11 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
       };
 
       // discard
-      let mustDiscard = true
+      let mustDiscard = true;
       try {
-        mustDiscard = await config.discard(error, action, retries)
-      } catch(e) {
-        console.warn(e)
+        mustDiscard = await config.discard(error, action, retries);
+      } catch (e) {
+        console.warn(e);
       }
 
       if (!mustDiscard) {

--- a/src/send.js
+++ b/src/send.js
@@ -28,22 +28,28 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
         dispatch(complete({ type: JS_ERROR, payload: e }, false));
       }
     })
-    .catch(error => {
+    .catch(async error => {
       const rollbackAction = metadata.rollback || {
         ...config.defaultRollback,
         meta: { ...config.defaultRollback.meta, offlineAction: action }
       };
 
       // discard
-      if (config.discard(error, action, retries)) {
-        dispatch(complete(rollbackAction, false, error));
-        return;
+      let mustDiscard = true
+      try {
+        mustDiscard = await config.discard(error, action, retries)
+      } catch(e) {
+        console.warn(e)
       }
-      const delay = config.retry(action, retries);
-      if (delay != null) {
-        dispatch(scheduleRetry(delay));
-        return;
+
+      if (!mustDiscard) {
+        const delay = config.retry(action, retries);
+        if (delay != null) {
+          dispatch(scheduleRetry(delay));
+          return;
+        }
       }
+
       dispatch(complete(rollbackAction, false, error));
     });
 };


### PR DESCRIPTION
This allow to return a Promise on the `discard` function so it's possible to decide asynchronously if a request should be discarded.