### PR TITLE
fix: breaking change caused by #1 adds backward compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,27 @@ const config = {
 ```
 
 The function is passed a callback, which you should call with boolean `true` when the app gets back online, and `false` when it goes offline.
+Additionally you can call it with an object containing as props `online` and `netInfo`. The `online` is a boolean that defines whether there's connection or not,
+the `netInfo` is an optional object containing details about the current network.
+ 
+The default detectNetwork.js provides an object with `online` as the only property.
+
+The default detectNetwork.native.js provides both the `online` and the `netInfo` props following `react-native` netInfo possible values.
+The payload object would follow the following example:
+```js
+/**
+* netInfo reach values follow react-native's NetInfo values
+* Cross-platform: ['none', 'wifi', 'cellular', 'unknown']
+* Android: ['bluetooth', 'ethernet', 'wimax']
+*/
+const payload = {
+  online: true, // determines the connection status
+  netInfo: {
+    reach: 'wifi', // network reach as provided by react native
+    isConnectionExpensive: false // whether connection is metered (only supported by android)
+  }
+};
+```
 
 #### Change how irreconcilable errors are detected
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -5,13 +5,18 @@ import {
   OFFLINE_BUSY
 } from './constants';
 
-export const networkStatusChanged = ({ online, netInfo }) => ({
-  type: OFFLINE_STATUS_CHANGED,
-  payload: {
-    online,
-    netInfo
+export const networkStatusChanged = params => {
+  let payload;
+  if (typeof payload === 'object') {
+    payload = params;
+  } else {
+    payload = { online: params };
   }
-});
+  return {
+    type: OFFLINE_STATUS_CHANGED,
+    payload
+  };
+};
 
 export const scheduleRetry = (delay = 0) => ({
   type: OFFLINE_SCHEDULE_RETRY,

--- a/src/actions.js
+++ b/src/actions.js
@@ -7,7 +7,7 @@ import {
 
 export const networkStatusChanged = params => {
   let payload;
-  if (typeof payload === 'object') {
+  if (typeof params === 'object') {
     payload = params;
   } else {
     payload = { online: params };


### PR DESCRIPTION
Addresses issue raised in #64 .

#1 Added a breaking change that slipped by me. Redux action `networkStatusChanged` changed it's signature expecting an object instead of a boolean, when overriding default detectNetwork.js the documented API would no longer work.

This PR includes support for both cases, a boolean representing only the connection status and the defaults payload returning `{ payload }` in web and `{ payload, netInfo }` in native.