### PR TITLE
check for undefined action.payload - REHYDRATE

### DIFF
--- a/src/updater.js
+++ b/src/updater.js
@@ -74,9 +74,10 @@ const offlineUpdater = function offlineUpdater(
   }
 
   if (action.type === PERSIST_REHYDRATE) {
+    const payload = action.payload ? action.payload.offline : {};
     return {
       ...state,
-      ...action.payload.offline,
+      ...payload,
       online: state.online,
       netInfo: state.netInfo,
       retryScheduled: initialState.retryScheduled,


### PR DESCRIPTION
With the possibility to integrate redux-offline middleware in the app middleware chain we have to check if the action.payload is undefined.