### PR TITLE
Return a promise from dispatch for offline actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,10 @@ Granular error handling is not yet implemented. You can use discard/retry, and
 if necessary to purge messages from your queue, you can filter `state.offline.outbox`
 in your reducers. Official support coming soon.
 
+#### Chain behavior off offline actions
+
+`store.dispatch()` returns a promise that you can use to chain behavior off offline actions, but be careful! A chief benefit of this library is that requests are tried across sessions, but promises do not last that long. So if you use this feature, know that your promise might not get resolved, even if the associated request is eventually delivered.
+
 #### Synchronise my state while the app is not open
 
 Background sync is not yet supported. Coming soon.

--- a/src/__tests__/offlineActionTracker.js
+++ b/src/__tests__/offlineActionTracker.js
@@ -1,0 +1,50 @@
+import { registerAction, resolveAction, rejectAction } from '../offlineActionTracker.js';
+
+test('resolves first action with correct transaction', () => {
+  const transaction = 0;
+  const promise = registerAction(transaction);
+
+  const data = { some: "data" };
+  resolveAction(transaction, data);
+
+  expect.assertions(1);
+  return promise.then(value => expect(value).toEqual(data));
+});
+
+test('rejects first action with correct transaction', () => {
+  const transaction = 0;
+  const promise = registerAction(transaction);
+
+  const data = { some: "data" };
+  rejectAction(transaction, data);
+
+  expect.assertions(1);
+  return promise.catch(error => expect(error).toEqual(data));
+});
+
+test('does not resolve first action with incorrect transaction', () => {
+  const transaction = 0;
+  const promise = registerAction(transaction);
+
+  const incorrectData = { incorrect: "data" };
+  resolveAction(transaction + 1, incorrectData);
+
+  const correctData = { some: "data" };
+  resolveAction(transaction, correctData);
+
+  expect.assertions(1);
+  return promise.then(value => expect(value).toEqual(correctData));
+});
+
+test('does not resolve second action with correct transaction', () => {
+  const array = [];
+
+  registerAction(0).then(() => array.push(0));
+  const promise = registerAction(1).then(() => array.push(1));
+  resolveAction(1);
+  resolveAction(0);
+  resolveAction(1);
+
+  expect.assertions(1);
+  return promise.then(() => expect(array).toEqual([0, 1]));
+});

--- a/src/offlineActionTracker.js
+++ b/src/offlineActionTracker.js
@@ -1,0 +1,25 @@
+const subscriptions = [];
+
+function registerAction(transaction) {
+  return new Promise((resolve, reject) => {
+    subscriptions.push({ transaction, resolve, reject });
+  });
+}
+
+function resolveAction(transaction, value) {
+  const subscription = subscriptions[0];
+  if (subscription && subscription.transaction === transaction) {
+    subscription.resolve(value);
+    subscriptions.shift();
+  }
+}
+
+function rejectAction(transaction, error) {
+  const subscription = subscriptions[0];
+  if (subscription && subscription.transaction === transaction) {
+    subscription.reject(error);
+    subscriptions.shift();
+  }
+}
+
+export { registerAction, resolveAction, rejectAction };

--- a/src/send.js
+++ b/src/send.js
@@ -1,16 +1,25 @@
 import { busy, scheduleRetry } from './actions';
 import { JS_ERROR } from './constants';
+import { resolveAction, rejectAction } from './offlineActionTracker';
 import type { Config, OfflineAction, ResultAction } from './types';
 
 const complete = (
   action: ResultAction,
   success: boolean,
-  payload: {}
-): ResultAction => ({
-  ...action,
-  payload,
-  meta: { ...action.meta, success, completed: true }
-});
+  payload: {},
+  offlineAction: OfflineAction
+): ResultAction => {
+  if (success) {
+    resolveAction(offlineAction.meta.transaction, payload);
+  } else {
+    rejectAction(offlineAction.meta.transaction, payload);
+  }
+  return {
+    ...action,
+    payload,
+    meta: { ...action.meta, success, completed: true }
+  };
+};
 
 const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
   const metadata = action.meta.offline;
@@ -23,9 +32,16 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
         meta: { ...config.defaultCommit.meta, offlineAction: action }
       };
       try {
-        dispatch(complete(commitAction, true, result));
+        return dispatch(complete(commitAction, true, result, action));
       } catch (error) {
-        dispatch(complete({ type: JS_ERROR, meta: { error } }, false));
+        return dispatch(
+          complete(
+            { type: JS_ERROR, meta: { error } },
+            false,
+            undefined,
+            action
+          )
+        );
       }
     })
     .catch(async error => {
@@ -45,12 +61,11 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
       if (!mustDiscard) {
         const delay = config.retry(action, retries);
         if (delay != null) {
-          dispatch(scheduleRetry(delay));
-          return;
+          return dispatch(scheduleRetry(delay));
         }
       }
 
-      dispatch(complete(rollbackAction, false, error));
+      return dispatch(complete(rollbackAction, false, error, action));
     });
 };
 


### PR DESCRIPTION
As requests are not guaranteed to resolve during the current session this approach isn't perfect, but it has been asked for quite a bit.