### PR TITLE
Include polyfills

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,8 @@
     "stage-3"
   ],
   "plugins": [
+    ["transform-class-properties", { "spec": true }],
     "transform-flow-strip-types",
-    ["transform-class-properties", { "spec": true }]
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-eslint": "^7.2.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-flow-strip-types": "^6.18.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-latest": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
     "eslint": "^4.6.1",
@@ -52,6 +53,7 @@
     "redux-persist-node-storage": "^1.0.2"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "redux-persist": "^4.5.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,6 +653,12 @@ babel-plugin-transform-regenerator@^6.24.1:
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
Include regenerator runtime and other necessary polyfills in the library rather than require the user to provide them as globals.

See redux-offline/redux-offline#63.