### PR TITLE
Feat/reducers refactor

### DIFF
--- a/src/reducers.js
+++ b/src/reducers.js
@@ -52,7 +52,7 @@ export const dequeue = (state: OfflineState): OfflineState => {
 
 export default {
   [OFFLINE_STATUS_CHANGED](state: OfflineState, action: Action): ?OfflineState {
-    if (!action.payload || typeof action.payload.online === 'boolean') {
+    if (!action.payload || typeof action.payload.online !== 'boolean') {
       return null;
     }
     return {

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,0 +1,98 @@
+// @flow
+
+import type { OfflineState, OfflineAction, ResultAction } from './types';
+import {
+  OFFLINE_STATUS_CHANGED,
+  OFFLINE_SCHEDULE_RETRY,
+  OFFLINE_COMPLETE_RETRY,
+  OFFLINE_BUSY,
+  RESET_STATE,
+  PERSIST_REHYDRATE
+} from './constants';
+
+type ControlAction =
+  | { type: OFFLINE_STATUS_CHANGED, payload: { online: boolean } }
+  | { type: OFFLINE_SCHEDULE_RETRY };
+
+export type Action = ControlAction | OfflineAction | ResultAction;
+
+export const initialState: OfflineState = {
+  busy: false,
+  lastTransaction: 0,
+  online: false,
+  outbox: [],
+  retryCount: 0,
+  retryScheduled: false,
+  netInfo: {
+    isConnectionExpensive: null,
+    reach: 'NONE'
+  }
+};
+
+export const enqueue = (state: OfflineState, action: Action): OfflineState => {
+  const transaction = state.lastTransaction + 1;
+  const stamped = { ...action, meta: { ...action.meta, transaction } };
+  const { outbox } = state;
+  return {
+    ...state,
+    lastTransaction: transaction,
+    outbox: [...outbox, stamped]
+  };
+};
+
+export const dequeue = (state: OfflineState): OfflineState => {
+  const [, ...rest] = state.outbox;
+  return {
+    ...state,
+    outbox: rest,
+    retryCount: 0,
+    busy: false
+  };
+};
+
+export default {
+  [OFFLINE_STATUS_CHANGED](state: OfflineState, action: Action): ?OfflineState {
+    if (!action.payload || typeof action.payload.online === 'boolean') {
+      return null;
+    }
+    return {
+      ...state,
+      online: action.payload.online,
+      netInfo: action.payload.netInfo
+    };
+  },
+  [PERSIST_REHYDRATE](state: OfflineState, action: Action): OfflineState {
+    return {
+      ...state,
+      ...action.payload.offline,
+      online: state.online,
+      netInfo: state.netInfo,
+      retryScheduled: initialState.retryScheduled,
+      retryCount: initialState.retryCount,
+      busy: initialState.busy
+    };
+  },
+  [OFFLINE_SCHEDULE_RETRY](state: OfflineState): OfflineState {
+    return {
+      ...state,
+      busy: false,
+      retryScheduled: true,
+      retryCount: state.retryCount + 1
+    };
+  },
+  [OFFLINE_COMPLETE_RETRY](state: OfflineState): OfflineState {
+    return { ...state, retryScheduled: false };
+  },
+  [OFFLINE_BUSY](state: OfflineState, action: Action): ?OfflineState {
+    if (!action.payload || typeof action.payload.busy !== 'boolean') {
+      return null;
+    }
+    return {
+      ...state,
+      busy: action.payload.busy
+    };
+  },
+  [RESET_STATE](state: OfflineState): OfflineState {
+    return { ...initialState, online: state.online, netInfo: state.netInfo };
+  }
+};

--- a/src/updater.js
+++ b/src/updater.js
@@ -13,7 +13,7 @@ const offlineUpdater = function offlineUpdater(
   const newState =
     reducers[action.type] && reducers[action.type](state, action);
 
-  if (newState !== null) {
+  if (newState !== null && typeof newState !== 'undefined') {
     return newState;
   }
 
@@ -27,7 +27,7 @@ const offlineUpdater = function offlineUpdater(
     return dequeue(state);
   }
 
-  return state;
+  return newState || state;
 };
 
 export const enhanceReducer = (reducer: any, config: $Shape<Config>) => (

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,110 +1,16 @@
 // @flow
 /* global $Shape */
 
-import type {
-  OfflineState,
-  OfflineAction,
-  ResultAction,
-  Config
-} from './types';
-import {
-  OFFLINE_STATUS_CHANGED,
-  OFFLINE_SCHEDULE_RETRY,
-  OFFLINE_COMPLETE_RETRY,
-  OFFLINE_BUSY,
-  RESET_STATE,
-  PERSIST_REHYDRATE
-} from './constants';
-
-type ControlAction =
-  | { type: OFFLINE_STATUS_CHANGED, payload: { online: boolean } }
-  | { type: OFFLINE_SCHEDULE_RETRY };
-
-const enqueue = (state: OfflineState, action: any): OfflineState => {
-  const transaction = state.lastTransaction + 1;
-  const stamped = { ...action, meta: { ...action.meta, transaction } };
-  const { outbox } = state;
-  return {
-    ...state,
-    lastTransaction: transaction,
-    outbox: [...outbox, stamped]
-  };
-};
-
-const dequeue = (state: OfflineState): OfflineState => {
-  const [, ...rest] = state.outbox;
-  return {
-    ...state,
-    outbox: rest,
-    retryCount: 0,
-    busy: false
-  };
-};
-
-const initialState: OfflineState = {
-  busy: false,
-  lastTransaction: 0,
-  online: false,
-  outbox: [],
-  retryCount: 0,
-  retryScheduled: false,
-  netInfo: {
-    isConnectionExpensive: null,
-    reach: 'NONE'
-  }
-};
-
-// @TODO: the typing of this is all kinds of wack
+import type { OfflineState, Config } from './types';
+import reducers, { initialState, enqueue, dequeue, Action } from './reducers';
 
 const offlineUpdater = function offlineUpdater(
   state: OfflineState = initialState,
-  action: ControlAction | OfflineAction | ResultAction
+  action: Action
 ): OfflineState {
   // Update online/offline status
-  if (
-    action.type === OFFLINE_STATUS_CHANGED &&
-    action.payload &&
-    typeof action.payload.online === 'boolean'
-  ) {
-    return {
-      ...state,
-      online: action.payload.online,
-      netInfo: action.payload.netInfo
-    };
-  }
-
-  if (action.type === PERSIST_REHYDRATE) {
-    return {
-      ...state,
-      ...action.payload.offline,
-      online: state.online,
-      netInfo: state.netInfo,
-      retryScheduled: initialState.retryScheduled,
-      retryCount: initialState.retryCount,
-      busy: initialState.busy
-    };
-  }
-
-  if (action.type === OFFLINE_SCHEDULE_RETRY) {
-    return {
-      ...state,
-      busy: false,
-      retryScheduled: true,
-      retryCount: state.retryCount + 1
-    };
-  }
-
-  if (action.type === OFFLINE_COMPLETE_RETRY) {
-    return { ...state, retryScheduled: false };
-  }
-
-  if (
-    action.type === OFFLINE_BUSY &&
-    action.payload &&
-    typeof action.payload.busy === 'boolean'
-  ) {
-    return { ...state, busy: action.payload.busy };
-  }
+  const newState =
+    reducers[action.type] && reducers[action.type](state, action);
 
   // Add offline actions to queue
   if (action.meta && action.meta.offline) {
@@ -116,11 +22,7 @@ const offlineUpdater = function offlineUpdater(
     return dequeue(state);
   }
 
-  if (action.type === RESET_STATE) {
-    return { ...initialState, online: state.online, netInfo: state.netInfo };
-  }
-
-  return state;
+  return newState || state;
 };
 
 export const enhanceReducer = (reducer: any, config: $Shape<Config>) => (

--- a/src/updater.js
+++ b/src/updater.js
@@ -2,7 +2,8 @@
 /* global $Shape */
 
 import type { OfflineState, Config } from './types';
-import reducers, { initialState, enqueue, dequeue, Action } from './reducers';
+import type { Action } from './reducers';
+import reducers, { initialState, enqueue, dequeue } from './reducers';
 
 const offlineUpdater = function offlineUpdater(
   state: OfflineState = initialState,

--- a/src/updater.js
+++ b/src/updater.js
@@ -13,6 +13,10 @@ const offlineUpdater = function offlineUpdater(
   const newState =
     reducers[action.type] && reducers[action.type](state, action);
 
+  if (newState !== null) {
+    return newState;
+  }
+
   // Add offline actions to queue
   if (action.meta && action.meta.offline) {
     return enqueue(state, action);
@@ -23,7 +27,7 @@ const offlineUpdater = function offlineUpdater(
     return dequeue(state);
   }
 
-  return newState || state;
+  return state;
 };
 
 export const enhanceReducer = (reducer: any, config: $Shape<Config>) => (


### PR DESCRIPTION
This PR includes:
- Refactors `updater.js` moving reducers logic into a new file `reducers.js`. Reducers are now pure functions. Includes typing into reducer functions.

Flow is still raising errors, but if you don't mind I prefer to address this later.