### PR TITLE
Include error on JS_ERROR

### DIFF
--- a/src/send.js
+++ b/src/send.js
@@ -25,7 +25,7 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
       try {
         dispatch(complete(commitAction, true, result));
       } catch (e) {
-        dispatch(complete({ type: JS_ERROR, payload: e }, false));
+        dispatch(complete({ type: JS_ERROR, error: e }, false));
       }
     })
     .catch(async error => {

--- a/src/send.js
+++ b/src/send.js
@@ -24,8 +24,8 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
       };
       try {
         dispatch(complete(commitAction, true, result));
-      } catch (e) {
-        dispatch(complete({ type: JS_ERROR, error: e }, false));
+      } catch (error) {
+        dispatch(complete({ type: JS_ERROR, meta: { error } }, false));
       }
     })
     .catch(async error => {


### PR DESCRIPTION
When a `JS_ERROR` is dispatched, the actual error was stored in the `payload` value, but that would be overwritten with `undefined` when `complete` was called, resulting in the actual error not being included in the dispatched `JS_ERROR` action.

I've modified it to include the error as `error` instead of `payload`. I wasn't sure if including it as the payload argument to `complete` would be preferable - let me know if that would make more sense.