### PR TITLE
Feature cancel offline specific action

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,4 @@ export const PERSIST_REHYDRATE = 'persist/REHYDRATE';
 export const JS_ERROR = 'Offline/JS_ERROR';
 export const DEFAULT_COMMIT = 'Offline/DEFAULT_COMMIT';
 export const DEFAULT_ROLLBACK = 'Offline/DEFAULT_ROLLBACK';
+export const DEQUEUE_ACTION = 'Offline/DEQUEUE_ACTION';


### PR DESCRIPTION
Hi there,

We've found redux-offline to be a great bundle of offline paradigms handling. However we have come across a use case not currently solved. Sometimes the use may do an action and want to cancel that action while being online.

For example maybe he sent 3 or 4 emails, but wants one to be cancelled before syncing with connection.

This way the use can dispatch a `DEQUEUE_ACTION` passing:

```
      dispatch({
        type: DEQUEUE_ACTION,
        payload: {
          type: 'CANCEL_EMAIL',
          payload: {
            emailId,
          },
        },
      })
```

If you consider merging this PR, I can refactor it and add docs & tests.

Thanks, cheers
Miguel