### PR TITLE
feat: event-chaining-poc

### DIFF
--- a/examples/web/client/package.json
+++ b/examples/web/client/package.json
@@ -8,7 +8,8 @@
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",
     "react-scripts": "1.0.14",
-    "redux": "^3.7.2"
+    "redux": "^3.7.2",
+    "redux-thunk": "^2.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/web/client/src/actions.js
+++ b/examples/web/client/src/actions.js
@@ -37,4 +37,43 @@ function failSometimes() {
   };
 }
 
+export function waterfallStart() {
+  return {
+    type: 'WATERFALL_START',
+    meta: {
+      offline: {
+        effect: { url: '/succeed-always' },
+        commit: { type: 'WATERFALL_START_COMMIT', meta: { observer: 'waterfallMidway' } },
+        rollback: { type: 'WATERFALL_START_ROLLBACK' }
+      }
+    }
+  };
+}
+
+export function waterfallMidway() {
+  return {
+    type: 'WATERFALL_MIDWAY',
+    meta: {
+      offline: {
+        effect: { url: '/succeed-always' },
+        commit: { type: 'WATERFALL_MIDWAY_COMMIT', meta: { observer: 'waterfallEnd' } },
+        rollback: { type: 'WATERFALL_MIDWAY_ROLLBACK' }
+      }
+    }
+  };
+}
+
+export function waterfallEnd() {
+  return {
+    type: 'WATERFALL_END',
+    meta: {
+      offline: {
+        effect: { url: '/succeed-always' },
+        commit: { type: 'WATERFALL_END_COMMIT' },
+        rollback: { type: 'WATERFALL_END_ROLLBACK' }
+      }
+    }
+  };
+}
+
 export { succeedAlways, succeedSometimes, failSometimes };

--- a/examples/web/client/src/components/App.js
+++ b/examples/web/client/src/components/App.js
@@ -1,39 +1,24 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import MakeRequests from './MakeRequests';
-import RequestsQueue from './RequestsQueue';
-import SyncStatus from './SyncStatus';
+import Basic from '../pages/Basic';
+import Promise from '../pages/Promise';
+import Observer from '../pages/Observer';
 import store from '../store';
 
 class App extends React.Component {
-
   state = {
-    page: 'home',
-    status: '',
-    time: null,
-    payload: '--null--'
+    page: 'home'
   };
 
   pages = {
-    home: { page: 'home', status: '', payload: '--null--', time: null },
-    basic: { page: 'basic', status: '', payload: '--null--', time: null },
-    promise: { page: 'promise' }
-  }
-
-  onSuccess = payload => this.setState(() => ({
-    time: Date.now(),
-    status: 'success',
-    payload: JSON.stringify(payload, null, '  ')
-  }))
-
-  onError = payload => this.setState(() => ({
-    time: Date.now(),
-    status: 'error',
-    payload: JSON.stringify(payload, null, '  ')
-  }))
+    home: { page: 'home' },
+    basic: { page: 'basic' },
+    promise: { page: 'promise' },
+    observer: { page: 'observer' }
+  };
 
   render() {
-    const { page, status, payload, time } = this.state;
+    const { page } = this.state;
     if (page === 'home') {
       return (
         <div>
@@ -43,6 +28,9 @@ class App extends React.Component {
           <button onClick={() => this.setState(this.pages.promise)}>
             promise
           </button>
+          <button onClick={() => this.setState(this.pages.observer)}>
+            observer
+          </button>
         </div>
       );
     }
@@ -50,23 +38,14 @@ class App extends React.Component {
     return (
       <Provider store={store}>
         <div className="container">
-          <div>
-            <SyncStatus />
-            <RequestsQueue />
-            <MakeRequests
-              successCallback={page === 'promise' && this.onSuccess}
-              errorCallback={page === 'promise' && this.onError}
-            />
-            <button
-              onClick={() => this.setState(this.pages.home)}>
-              home
-            </button>
-          </div>
+          {page === 'basic' &&
+            <Basic goBack={() => this.setState(this.pages.home)} />
+          }
           {page === 'promise' &&
-            <pre className={`promise-box ${status}`}>
-              <p>{status} {time}</p>
-              <code>{payload}</code>
-            </pre>
+            <Promise goBack={() => this.setState(this.pages.home)} />
+          }
+          {page === 'observer' &&
+            <Observer />
           }
         </div>
       </Provider>

--- a/examples/web/client/src/index.css
+++ b/examples/web/client/src/index.css
@@ -19,15 +19,31 @@ body {
   width: 600px;
 }
 
-.promise-box {
+.code-box {
   width: 450px;
   overflow: auto;
 }
 
-.promise-box.success > code {
+.code-box.success > code {
      color: #1cbc51;
 }
 
-.promise-box.error > code {
+.code-box.error > code {
   color: #b11f0b;
+}
+
+.code-box.auto {
+  width: 100%;
+  height: 90%;
+}
+
+.waterfall-step {
+  height: 150px;
+  width: 150px;
+  border: dashed 1px #000;
+}
+
+.waterfall-step.active {
+  border: 0;
+  background-color: #1cbc51;
 }

--- a/examples/web/client/src/pages/Basic.js
+++ b/examples/web/client/src/pages/Basic.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import MakeRequests from '../components/MakeRequests';
+import RequestsQueue from '../components/RequestsQueue';
+import SyncStatus from '../components/SyncStatus';
+
+export default ({ goBack }) => (
+  <div>
+    <SyncStatus />
+    <RequestsQueue />
+    <MakeRequests />
+    <button onClick={goBack}> back </button>
+  </div>
+);

--- a/examples/web/client/src/pages/Observer.js
+++ b/examples/web/client/src/pages/Observer.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import RequestsQueue from '../components/RequestsQueue';
+import SyncStatus from '../components/SyncStatus';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { waterfallStart } from '../actions';
+
+class Observer extends React.Component {
+  render() {
+    const { goBack, waterfallStep, start, waterfallResult } = this.props;
+    const getActive = step => (waterfallStep === step ? 'active' : '');
+
+    const codeBlock = isActive => isActive && (
+      <pre className="code-box auto">
+        <code>
+          {JSON.stringify(waterfallResult, null, '  ')}
+        </code>
+      </pre>
+    )
+    return (
+      <div>
+        <div>
+          <SyncStatus />
+          <RequestsQueue />
+          <button onClick={start}> start </button>
+          <button onClick={goBack}> back </button>
+        </div>
+        <div className="container">
+          <div className={`waterfall-step ${getActive(1)}`}>
+            start
+            {codeBlock(waterfallStep === 1)}
+          </div>
+          <div className={`waterfall-step ${getActive(2)}`}>
+            midway
+            {codeBlock(waterfallStep === 2)}          </div>
+          <div className={`waterfall-step ${getActive(3)}`}>
+            end
+            {codeBlock(waterfallStep === 3)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    waterfallStep: state.waterfallStep,
+    waterfallResult: state.waterfallResult
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    {
+      start: waterfallStart
+    },
+    dispatch
+  );
+}
+
+const ObserverContainer = connect(mapStateToProps, mapDispatchToProps)(Observer);
+
+export { Observer };
+export default ObserverContainer;

--- a/examples/web/client/src/pages/Promise.js
+++ b/examples/web/client/src/pages/Promise.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import MakeRequests from '../components/MakeRequests';
+import RequestsQueue from '../components/RequestsQueue';
+import SyncStatus from '../components/SyncStatus';
+
+export default class Promise extends React.Component {
+  state = {
+    status: '',
+    time: null,
+    payload: '--null--'
+  }
+
+  onSuccess = payload => this.setState(() => ({
+      time: Date.now(),
+      status: 'success',
+      payload: JSON.stringify(payload, null, '  ')
+    }));
+
+  onError = payload => this.setState(() => ({
+      time: Date.now(),
+      status: 'error',
+      payload: JSON.stringify(payload, null, '  ')
+    }));
+
+  render() {
+    const { goBack} = this.props;
+    const { status, payload, time } = this.state;
+    return (
+      <div className="container">
+        <div>
+          <SyncStatus />
+          <RequestsQueue />
+          <MakeRequests
+            successCallback={this.onSuccess}
+            errorCallback={this.onError}
+          />
+          <button onClick={goBack}> back </button>
+        </div>
+        <pre className={`code-box ${status}`}>
+          <p>{status} {time}</p>
+          <code>{payload}</code>
+        </pre>
+      </div>
+    );
+  }
+}

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -13,6 +13,7 @@ function noop() {}
 beforeEach(() => storage.removeItem(storageKey, noop) );
 
 const defaultConfig = applyDefaults({
+  observerList: {},
   effect: jest.fn(() => Promise.resolve()),
   persistOptions: { storage }
 });

--- a/src/__tests__/middleware.js
+++ b/src/__tests__/middleware.js
@@ -29,7 +29,8 @@ const defaultOfflineState = {
   netInfo: {
     isConnectionExpensive: null,
     reach: 'NONE'
-  }
+  },
+  observerList: {}
 };
 
 function setup(offlineState = {}) {

--- a/src/__tests__/send.js
+++ b/src/__tests__/send.js
@@ -16,6 +16,7 @@ function setup(partialConfig) {
     retry: () => DELAY,
     defaultCommit: defaultCommitAction,
     defaultRollback: defaultRollbackAction,
+    observerList: {}
   };
 
   return {

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -10,6 +10,7 @@ import offlineStateLens from './offlineStateLens';
 import queue from './queue';
 
 export default {
+  observerPool: {},
   rehydrate: true, // backward compatibility, TODO remove in the next breaking change version
   persist,
   detectNetwork,

--- a/src/send.js
+++ b/src/send.js
@@ -32,7 +32,12 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
         meta: { ...config.defaultCommit.meta, offlineAction: action }
       };
       try {
-        return dispatch(complete(commitAction, true, result, action));
+        dispatch(complete(commitAction, true, result, action));
+        const commitObserver =
+          commitAction.meta &&
+          commitAction.meta.observer &&
+          config.observerPool[commitAction.meta.observer];
+        return commitObserver && dispatch(commitObserver());
       } catch (error) {
         return dispatch(
           complete(
@@ -65,7 +70,12 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
         }
       }
 
-      return dispatch(complete(rollbackAction, false, error, action));
+      dispatch(complete(rollbackAction, false, error, action));
+      const rollbackObserver =
+        rollbackAction.meta &&
+        rollbackAction.meta.observer &&
+        config.observerPool[rollbackAction.meta.observer];
+      return rollbackObserver && dispatch(rollbackObserver());
     });
 };
 


### PR DESCRIPTION
I was thinking about the new promise feature we just merged, and something was still bothering me. I'm not sure it's the best solution, and if we release we'll have to maintain it, and I'm afraid people will abuse from it.

Basically...
![1mt4d7](https://user-images.githubusercontent.com/12124839/35266944-03c60004-0025-11e8-883b-7c136da81618.jpg)

**TLDR;** I came up with a new idea, and went through to see were it lead me, this is the result.

Instead of the promise based solution, first I thought about events. Dispatching an event over some channel and letting that subscriber react. But then I figured we didn't really needed events because redux. So I imagined setting up a pool of observers and dispatching them on commit.

Finally what I got is chainable actions between sessions. This is a POC and could be improved.

![screen shot 2018-01-23 at 09 53 15](https://user-images.githubusercontent.com/12124839/35266837-b1ed75a0-0024-11e8-8647-5ddc5432e0d2.png)

![waterfall](https://user-images.githubusercontent.com/12124839/35266910-efc7c7a4-0024-11e8-8594-c506d3c5a444.gif)
 

@wacii Please play with this and let me know what do you think.