### PR TITLE
Able to dispatch a thunk after commit or rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,14 +297,14 @@ The reason the default behaviour is to desperately try to make the requests succ
 
 ### What about if I want to dispatch a thunk after commit or rollback is dispatched?
 
-You can do it adding redux-offline-thunk middleware to your project:
+You can do it importing redux-offline-thunk-middleware to your project:
 
 ```js
 
  import { applyMiddleware, createStore, compose } from 'redux';
  import { offline } from '@redux-offline/redux-offline';
  import offlineConfig from '@redux-offline/redux-offline/lib/defaults';
- import reduxOfflineDispatch from '@redux-offline/redux-offline/lib/redux-offline-thunk';
+ import reduxOfflineThunkMiddleware from '@redux-offline/redux-offline/lib/thunk-middleware';
  // you have to import every thunk action that you need to dispatch after redux-offline commit or rollback
  import { thunkAction1, thunkAction2 } from 'myproject-src/redux/actions';
 
@@ -314,7 +314,7 @@ const store = createStore(
   reducer,
   preloadedState,
   compose(
-    applyMiddleware(reduxOfflineThunk({ thunkAction1, thunkAction2 })),
+    applyMiddleware(reduxOfflineThunkMiddleware({ thunkAction1, thunkAction2 })),
     offline(offlineConfig)
   )
 );

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ const store = createStore(
 );
 ```
 
-Then the action that have to dispatch a thunk needs to be decorated:
+Then the action that have to dispatch a thunk needs to be decorated with `thunk`:
 
 ```js
 const followUser = userId => ({

--- a/README.md
+++ b/README.md
@@ -295,6 +295,59 @@ Retrying a request for this long may seem excessive, and for some use cases it c
 The reason the default behaviour is to desperately try to make the requests succeed is that we really, really want to avoid having to deal with conflict resolution...
 
 
+### What about if I want to dispatch a thunk after commit or rollback is dispatched?
+
+You can do it adding redux-offline-thunk middleware to your project:
+
+```js
+
+ import { applyMiddleware, createStore, compose } from 'redux';
+ import { offline } from '@redux-offline/redux-offline';
+ import offlineConfig from '@redux-offline/redux-offline/lib/defaults';
+ import reduxOfflineDispatch from '@redux-offline/redux-offline/lib/redux-offline-thunk';
+ // you have to import every thunk action that you need to dispatch after redux-offline commit or rollback
+ import { thunkAction1, thunkAction2 } from 'myproject-src/redux/actions';
+
+// ...
+
+const store = createStore(
+  reducer,
+  preloadedState,
+  compose(
+    applyMiddleware(reduxOfflineThunk({ thunkAction1, thunkAction2 })),
+    offline(offlineConfig)
+  )
+);
+```
+
+Then the action that have to dispatch a thunk needs to be decorated:
+
+```js
+const followUser = userId => ({
+  type: 'FOLLOW_USER_REQUEST',
+  payload: { userId },
+  meta: {
+    offline: {
+      // the network action to execute:
+      effect: { url: '/api/follow', method: 'POST', body: { userId } },
+      // action to dispatch when effect succeeds:
+      commit: { 
+        type: 'FOLLOW_USER_COMMIT', 
+        meta: { 
+          userId,
+          thunk: {
+            functionName: 'thunkAction1',
+            params: [userId, 'some needed data']
+          }
+        } 
+      },
+      // action to dispatch if network action fails permanently:
+      rollback: { type: 'FOLLOW_USER_ROLLBACK', meta: { userId } }
+    }
+  }
+});
+```
+
 ## Configuration
 
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ The reason the default behaviour is to desperately try to make the requests succ
 
 ### What about if I want to dispatch a thunk after commit or rollback is dispatched?
 
-You can do it importing redux-offline-thunk-middleware to your project:
+You can do it importing reduxOfflineThunkMiddleware to your project:
 
 ```js
 

--- a/src/redux-offline-thunk.js
+++ b/src/redux-offline-thunk.js
@@ -1,0 +1,15 @@
+
+const reduxOfflineThunk = thunks => store => next => action => {
+  const result = next(action)
+
+  if (typeof action === 'object'
+    && action.meta && action.meta.thunk
+    && typeof action.meta.thunk === 'object'
+  ) {
+    store.dispatch(thunks[action.meta.thunk.func].apply(null, action.meta.thunk.params))
+  }
+  
+  return result
+}
+
+export default reduxOfflineThunk

--- a/src/redux-offline-thunk.js
+++ b/src/redux-offline-thunk.js
@@ -6,7 +6,7 @@ const reduxOfflineThunk = thunks => store => next => action => {
     && action.meta && action.meta.thunk
     && typeof action.meta.thunk === 'object'
   ) {
-    store.dispatch(thunks[action.meta.thunk.func].apply(null, action.meta.thunk.params))
+    store.dispatch(thunks[action.meta.thunk.functionName].apply(null, action.meta.thunk.params))
   }
   
   return result

--- a/src/thunk-middleware.js
+++ b/src/thunk-middleware.js
@@ -1,14 +1,18 @@
 const reduxOfflineThunkMiddleware = thunks => store => next => action => {
   const result = next(action);
 
-  if (typeof action === 'object' &&
+  if (
+    typeof action === 'object' &&
     action.meta && action.meta.thunk &&
     typeof action.meta.thunk === 'object'
   ) {
-    store.dispatch(thunks[action.meta.thunk.functionName].apply(null, action.meta.thunk.params));
+    store.dispatch(thunks[action.meta.thunk.functionName].apply(
+      null,
+      action.meta.thunk.params
+    ));
   }
-  
+
   return result;
-}
+};
 
 export default reduxOfflineThunkMiddleware;

--- a/src/thunk-middleware.js
+++ b/src/thunk-middleware.js
@@ -3,13 +3,16 @@ const reduxOfflineThunkMiddleware = thunks => store => next => action => {
 
   if (
     typeof action === 'object' &&
-    action.meta && action.meta.thunk &&
+    action.meta &&
+    action.meta.thunk &&
     typeof action.meta.thunk === 'object'
   ) {
-    store.dispatch(thunks[action.meta.thunk.functionName].apply(
-      null,
-      action.meta.thunk.params
-    ));
+    store.dispatch(
+      thunks[action.meta.thunk.functionName].apply(
+        null,
+        action.meta.thunk.params
+      )
+    );
   }
 
   return result;

--- a/src/thunk-middleware.js
+++ b/src/thunk-middleware.js
@@ -1,15 +1,14 @@
-
 const reduxOfflineThunkMiddleware = thunks => store => next => action => {
-  const result = next(action)
+  const result = next(action);
 
-  if (typeof action === 'object'
-    && action.meta && action.meta.thunk
-    && typeof action.meta.thunk === 'object'
+  if (typeof action === 'object' &&
+    action.meta && action.meta.thunk &&
+    typeof action.meta.thunk === 'object'
   ) {
-    store.dispatch(thunks[action.meta.thunk.functionName].apply(null, action.meta.thunk.params))
+    store.dispatch(thunks[action.meta.thunk.functionName].apply(null, action.meta.thunk.params));
   }
   
-  return result
+  return result;
 }
 
-export default reduxOfflineThunkMiddleware
+export default reduxOfflineThunkMiddleware;

--- a/src/thunk-middleware.js
+++ b/src/thunk-middleware.js
@@ -1,5 +1,5 @@
 
-const reduxOfflineThunk = thunks => store => next => action => {
+const reduxOfflineThunkMiddleware = thunks => store => next => action => {
   const result = next(action)
 
   if (typeof action === 'object'
@@ -12,4 +12,4 @@ const reduxOfflineThunk = thunks => store => next => action => {
   return result
 }
 
-export default reduxOfflineThunk
+export default reduxOfflineThunkMiddleware


### PR DESCRIPTION
Sometimes we need to dispatch an action after another action is dispatched. We can use redux-thunk for this purpose. But currently redux-offline cannot store thunks because redux store cannot store pure functions. This is the reason why I created this middleware. We cannot persist a pure function but we can persist the name of the function and its params, that is the key. I hope you find my solution good.

Regards,

David Escalera