### PR TITLE
Add experimental & unstable to chaining actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ const config = {
 };
 ```
 
-#### Chain behavior off offline actions
+#### Chain behavior off offline actions (EXPERIMENTAL & UNSTABLE)
 
 `store.dispatch()` returns a promise that you can use to chain behavior off offline actions, but be careful! A chief benefit of this library is that requests are tried across sessions, but promises do not last that long. So if you use this feature, know that your promise might not get resolved, even if the associated request is eventually delivered.
 


### PR DESCRIPTION
I think it's better to label the current action chaining implementation as experimental and unstable. This let's people know that in some edge cases unexpected 💩  might happen. And with this we can release what we have and further iterate over the other chaining PRs.

I'd like to know if you're ok with this. @wacii