### PR TITLE
Fix bug #179: Default discard does not detect NetworkError correctly

### DIFF
--- a/src/__tests__/defaults/discard.js
+++ b/src/__tests__/defaults/discard.js
@@ -1,0 +1,22 @@
+import discard from '../../defaults/discard';
+
+test('discards non-http error', () => {
+  const error = { message: 'Non-http error' };
+  const action = { type: 'DISCARD', meta: { offline: { effect: {} } } };
+
+  expect(discard(error, action)).toEqual(true);
+});
+
+test('discards http 4xx errors', () => {
+  const error = { status: 404 };
+  const action = { type: 'DISCARD', meta: { offline: { effect: {} } } };
+
+  expect(discard(error, action)).toEqual(true);
+});
+
+test('does not discard http 5xx errors', () => {
+  const error = { status: 500 };
+  const action = { type: 'DISCARD', meta: { offline: { effect: {} } } };
+
+  expect(discard(error, action)).toEqual(false);
+});

--- a/src/defaults/effect.js
+++ b/src/defaults/effect.js
@@ -11,7 +11,6 @@ export function NetworkError(response: {} | string, status: number) {
 
 // $FlowFixMe
 NetworkError.prototype = Error.prototype;
-NetworkError.prototype.status = null;
 
 const tryParseJSON = (json: string): ?{} => {
   if (!json) {


### PR DESCRIPTION
Fixes bug #179. Removes status from `NetworkError.prototype` which caused `discard` function's status property check to fail.