### PR TITLE
fix: includes missing flow types due to queue config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   rules: {
     'comma-dangle': 'off',
-    'import/prefer-default-export': ['warn'],
+    'import/prefer-default-export': 0,
     'function-paren-newline': ['error', 'consistent'],
     'prettier/prettier': ['error', {
       'singleQuote': true,

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [ignore]
-
+.*/examples/.*
 [options]
 suppress_comment=.*\\$FlowIssue
 suppress_comment=.*\\$FlowFixMe

--- a/src/types.js
+++ b/src/types.js
@@ -27,7 +27,7 @@ export type OfflineMetadata = {
 // since it can be any user passed string
 export type OfflineAction = {
   type: string,
-  payload?: {},
+  payload: ?{},
   meta: {
     transaction?: number,
     offline: OfflineMetadata
@@ -89,5 +89,16 @@ export type Config = {
   persistAutoRehydrate: (config: ?{}) => (next: any) => any,
   offlineStateLens: (
     state: any
-  ) => { get: OfflineState, set: (offlineState: ?OfflineState) => any }
+  ) => { get: OfflineState, set: (offlineState: ?OfflineState) => any },
+  queue: {
+    enqueue: (
+      array: Array<OfflineAction>,
+      item: OfflineAction
+    ) => Array<OfflineAction>,
+    dequeue: (
+      array: Array<OfflineAction>,
+      item: ResultAction
+    ) => Array<OfflineAction>,
+    peek: (array: Array<OfflineAction>) => OfflineAction
+  }
 };

--- a/src/updater.js
+++ b/src/updater.js
@@ -4,8 +4,9 @@
 import type {
   OfflineStatusChangeAction,
   OfflineScheduleRetryAction,
-  OfflineState,
   PersistRehydrateAction,
+  OfflineAction,
+  OfflineState,
   ResultAction,
   Config
 } from './types';
@@ -85,7 +86,10 @@ const buildOfflineUpdater = (dequeue, enqueue) =>
     // Add offline actions to queue
     if (action.meta && action.meta.offline) {
       const transaction = state.lastTransaction + 1;
-      const stamped = { ...action, meta: { ...action.meta, transaction } };
+      const stamped = (({
+        ...action,
+        meta: { ...action.meta, transaction }
+      }: any): OfflineAction);
       const { outbox } = state;
       return {
         ...state,


### PR DESCRIPTION
This adds missing flow types due to flow and also adds a type cast to the enqueue call. Flow is no longer complaining.