### PR TITLE
Fix HMR

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -10,7 +10,7 @@ const storage = new AsyncNodeStorage("/tmp/storageDir");
 const storageKey = `${KEY_PREFIX}offline`;
 function noop() {}
 
-beforeEach(() => storage.removeItem(storageKey, noop) );
+beforeEach(done => storage.removeItem(storageKey, done) );
 
 const defaultConfig = applyDefaults({
   effect: jest.fn(() => Promise.resolve()),

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -50,6 +50,21 @@ test("supports HMR by overriding `replaceReducer()`", () => {
   expect(store.getState()).toHaveProperty("offline");
 });
 
+test("createOffline() supports HMR", () => {
+  const { middleware, enhanceReducer, enhanceStore } =
+    createOffline(defaultConfig);
+  const reducer = enhanceReducer(defaultReducer);
+  const store = createStore(reducer, compose(
+    applyMiddleware(middleware),
+    enhanceStore
+  ));
+  store.replaceReducer(combineReducers({
+    data: defaultReducer
+  }));
+  store.dispatch({ type: "SOME_ACTION" });
+  expect(store.getState()).toHaveProperty("offline");
+});
+
 // see https://github.com/redux-offline/redux-offline/issues/4
 test("restores offline outbox when rehydrates", done => {
   const actions = [{

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,4 +1,4 @@
-import { applyMiddleware, compose, createStore } from "redux";
+import { applyMiddleware, combineReducers, compose, createStore } from "redux";
 import { KEY_PREFIX } from "redux-persist/lib/constants"
 import { AsyncNodeStorage } from "redux-persist-node-storage";
 import instrument from "redux-devtools-instrument";
@@ -41,16 +41,13 @@ test("createOffline() creates storeEnhancer", () => {
 });
 
 // see https://github.com/redux-offline/redux-offline/issues/31
-test("supports HMR by overriding `replaceReducer()`", done => {
-  const store = offline({
-    ...defaultConfig,
-    persistCallback() {
-      store.replaceReducer(defaultReducer);
-      store.dispatch({ type: "SOME_ACTION" });
-      expect(store.getState()).toHaveProperty("offline");
-      done();
-    }
-  })(createStore)(defaultReducer);
+test("supports HMR by overriding `replaceReducer()`", () => {
+  const store = offline(defaultConfig)(createStore)(defaultReducer);
+  store.replaceReducer(combineReducers({
+    data: defaultReducer
+  }));
+  store.dispatch({ type: "SOME_ACTION" });
+  expect(store.getState()).toHaveProperty("offline");
 });
 
 // see https://github.com/redux-offline/redux-offline/issues/4

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -11,6 +11,7 @@ const storageKey = `${KEY_PREFIX}offline`;
 function noop() {}
 
 beforeEach(done => storage.removeItem(storageKey, done) );
+afterEach(() => defaultConfig.effect.mockClear());
 
 const defaultConfig = applyDefaults({
   effect: jest.fn(() => Promise.resolve()),

--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,8 @@ export const offline = (userConfig: $Shape<Config> = {}) => (
     return baseReplaceReducer(enhanceReducer(nextReducer, config));
   };
   const store = {
-    replaceReducer,
-    ...initialStore
+    ...initialStore,
+    replaceReducer
   };
 
   // launch store persistor

--- a/src/index.js
+++ b/src/index.js
@@ -47,19 +47,15 @@ export const offline = (userConfig: $Shape<Config> = {}) => (
       : offlineMiddleware;
 
   // create store
-  const initialStore = offlineEnhancer(createStore)(
+  const store = offlineEnhancer(createStore)(
     offlineReducer,
     preloadedState,
     enhancer
   );
 
-  const baseReplaceReducer = initialStore.replaceReducer.bind(initialStore);
-  const replaceReducer = function replaceReducer(nextReducer) {
+  const baseReplaceReducer = store.replaceReducer.bind(store);
+  store.replaceReducer = function replaceReducer(nextReducer) {
     return baseReplaceReducer(enhanceReducer(nextReducer, config));
-  };
-  const store = {
-    ...initialStore,
-    replaceReducer
   };
 
   // launch store persistor


### PR DESCRIPTION
HMR support was broken in `offline()` (but not `createOffline()`). The offending code:

```js
store = {
  replaceReducer,
  ...initialStore
}
```

So `replaceReducer()` was immediately overridden. And the tests didn't catch it. Double sigh.

There were also problems with the index tests; state was sometimes being shared by the node storage fake...and always by the effect mock. So those had to be fixed first.

See #187