### PR TITLE
Add missing bracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ const ordersReducer = (state, action) {
     case 'COMPLETE_ORDER':
       return {
         ...state,
-        submitting: {...state.submitting, [action.payload.orderId]: true
+        submitting: { ...state.submitting, [action.payload.orderId]: true }
       };
     case 'COMPLETE_ORDER_COMMIT':
       return {


### PR DESCRIPTION
One case's return object was missing a closing bracket.