### PR TITLE
Optional promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ export type Config = {
     enqueue: (outbox: Array<OfflineAction>, action: OfflineAction) => Array<OfflineAction>,
     dequeue: (outbox: Array<OfflineAction>, action: OfflineAction) => Array<OfflineAction>,
     peek: (outbox: Array<OfflineAction>) => OfflineAction
-  }
+  },
+  returnPromises: boolean
 };
 ```
 
@@ -533,6 +534,8 @@ const config = {
 #### Chain behavior off offline actions (EXPERIMENTAL & UNSTABLE)
 
 `store.dispatch()` returns a promise that you can use to chain behavior off offline actions, but be careful! A chief benefit of this library is that requests are tried across sessions, but promises do not last that long. So if you use this feature, know that your promise might not get resolved, even if the associated request is eventually delivered.
+
+> You must opt-in to this feature by setting `offlineConfig.returnPromises = true`.
 
 #### Synchronise my state while the app is not open
 

--- a/examples/web/client/src/components/MakeRequests.js
+++ b/examples/web/client/src/components/MakeRequests.js
@@ -3,18 +3,15 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { succeedAlways, succeedSometimes, failSometimes } from '../actions';
 
+const noop = () => {};
+
 class MakeRequests extends React.Component {
 
   buildHandler = (handler) => {
     const { successCallback, errorCallback } = this.props;
-    let promise;
-    if (successCallback) {
-      promise = handler().then(successCallback);
-    }
-    if (errorCallback) {
-      promise.catch(errorCallback);
-    }
-    return promise || handler();
+    return handler()
+      .then(successCallback || noop)
+      .catch(errorCallback || noop);
   }
 
   onSucceedAlways = () => this.buildHandler(this.props.onSucceedAlways)

--- a/examples/web/client/src/store.js
+++ b/examples/web/client/src/store.js
@@ -26,7 +26,8 @@ const config = {
   ...defaultConfig,
   retry(_action, retries) {
     return (retries + 1) * 1000;
-  }
+  },
+  returnPromises: true
 };
 
 function tickMiddleware(store) {

--- a/src/__tests__/middleware.js
+++ b/src/__tests__/middleware.js
@@ -144,8 +144,13 @@ describe('on OFFLINE_SCHEDULE_RETRY', () => {
 });
 
 describe('offlineActionTracker integration', () => {
+  let config, store, next;
+  beforeEach(() => {
+    ({ config, store, next } = setup())
+    config = { ...config, returnPromises: true };
+  });
+
   test('returns a promise that can be resolved', () => {
-    const { config, store, next } = setup();
     const promise = createOfflineMiddleware(config)(store)(next)(offlineAction);
 
     const transaction = 0;
@@ -157,7 +162,6 @@ describe('offlineActionTracker integration', () => {
   });
 
   test('returns a promise that can be rejected', () => {
-    const { config, store, next, action } = setup();
     const promise = createOfflineMiddleware(config)(store)(next)(offlineAction);
 
     const transaction = 0;

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -20,5 +20,6 @@ export default {
   defaultRollback,
   persistAutoRehydrate,
   offlineStateLens,
-  queue
+  queue,
+  returnPromises: false
 };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -47,5 +47,5 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (
     send(offlineAction, store.dispatch, config, offline.retryCount);
   }
 
-  return promise || result;
+  return config.returnPromises ? promise || result : result;
 };


### PR DESCRIPTION
Set `offlineConfig.returnPromises = true` to return promises from `dispatch()`.

Closes #191

~edit: Ah, this includes commits from another PR. I'll clean this up in a bit.~