### PR TITLE
Toggle offlineActionTracker with returnPromises

### DIFF
--- a/src/__tests__/offlineActionTracker.js
+++ b/src/__tests__/offlineActionTracker.js
@@ -1,4 +1,9 @@
-import { registerAction, resolveAction, rejectAction } from '../offlineActionTracker.js';
+import offlineActionTracker from '../offlineActionTracker.js';
+const {
+  registerAction,
+  resolveAction,
+  rejectAction
+} = offlineActionTracker.withPromises;
 
 test('resolves first action with correct transaction', () => {
   const transaction = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { createOfflineMiddleware } from './middleware';
 import { enhanceReducer } from './updater';
 import { applyDefaults } from './config';
 import { networkStatusChanged } from './actions';
+import offlineActionTracker from './offlineActionTracker';
 
 // @TODO: Take createStore as config?
 const warnIfNotReduxAction = (config: $Shape<Config>, key: string) => {
@@ -33,6 +34,12 @@ export const offline = (userConfig: $Shape<Config> = {}) => (
 
   warnIfNotReduxAction(config, 'defaultCommit');
   warnIfNotReduxAction(config, 'defaultRollback');
+
+  // toggle experimental returned promises
+  config.offlineActionTracker = config.returnPromises
+    ? offlineActionTracker.withPromises
+    : offlineActionTracker.withoutPromises;
+  delete config.returnPromises;
 
   // wraps userland reducer with a top-level
   // reducer that handles offline state updating
@@ -75,6 +82,12 @@ export const offline = (userConfig: $Shape<Config> = {}) => (
 
 export const createOffline = (userConfig: $Shape<Config> = {}) => {
   const config = applyDefaults(userConfig);
+
+  // toggle experimental returned promises
+  config.offlineActionTracker = config.returnPromises
+    ? offlineActionTracker.withPromises
+    : offlineActionTracker.withoutPromises;
+  delete config.returnPromises;
 
   warnIfNotReduxAction(config, 'defaultCommit');
   warnIfNotReduxAction(config, 'defaultRollback');

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -4,7 +4,6 @@ import type { AppState, Config } from './types';
 import { OFFLINE_SEND, OFFLINE_SCHEDULE_RETRY } from './constants';
 import { completeRetry } from './actions';
 import send from './send';
-import { registerAction } from './offlineActionTracker';
 
 const after = (timeout = 0) =>
   new Promise(resolve => setTimeout(resolve, timeout));
@@ -23,6 +22,7 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (
 
   // create promise to return on enqueue offline action
   if (action.meta && action.meta.offline) {
+    const { registerAction } = config.offlineActionTracker;
     promise = registerAction(offline.lastTransaction);
   }
 
@@ -47,5 +47,5 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (
     send(offlineAction, store.dispatch, config, offline.retryCount);
   }
 
-  return config.returnPromises ? promise || result : result;
+  return promise || result;
 };

--- a/src/offlineActionTracker.js
+++ b/src/offlineActionTracker.js
@@ -22,4 +22,19 @@ function rejectAction(transaction, error) {
   }
 }
 
-export { registerAction, resolveAction, rejectAction };
+const withPromises = {
+  registerAction,
+  resolveAction,
+  rejectAction
+};
+
+const withoutPromises = {
+  registerAction() {},
+  resolveAction() {},
+  rejectAction() {}
+};
+
+export default {
+  withPromises,
+  withoutPromises
+};

--- a/src/send.js
+++ b/src/send.js
@@ -1,14 +1,15 @@
 import { busy, scheduleRetry } from './actions';
 import { JS_ERROR } from './constants';
-import { resolveAction, rejectAction } from './offlineActionTracker';
 import type { Config, OfflineAction, ResultAction } from './types';
 
 const complete = (
   action: ResultAction,
   success: boolean,
   payload: {},
-  offlineAction: OfflineAction
+  offlineAction: OfflineAction,
+  config: Config
 ): ResultAction => {
+  const { resolveAction, rejectAction } = config.offlineActionTracker;
   if (success) {
     resolveAction(offlineAction.meta.transaction, payload);
   } else {
@@ -32,14 +33,15 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
         meta: { ...config.defaultCommit.meta, offlineAction: action }
       };
       try {
-        return dispatch(complete(commitAction, true, result, action));
+        return dispatch(complete(commitAction, true, result, action, config));
       } catch (error) {
         return dispatch(
           complete(
             { type: JS_ERROR, meta: { error } },
             false,
             undefined,
-            action
+            action,
+            config
           )
         );
       }
@@ -65,7 +67,7 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
         }
       }
 
-      return dispatch(complete(rollbackAction, false, error, action));
+      return dispatch(complete(rollbackAction, false, error, action, config));
     });
 };
 


### PR DESCRIPTION
Simply not returning the promise produced by the experimental `offlineActionTracker` was not enough to prevent errors.

Instead an action tracker is provided on `offlineConfig` rather than being imported as a module when needed. This allows the tracker to be replaced when promises are not desired.

I stuck the tracker on config because that is where we generally put such things, but as the user is not providing it, this is probably not the right place for it. Since this is still experimental and putting on config caused minimal changes, I thought it OK for now.

Closes #191