### PR TITLE
Add the current action to peek

### DIFF
--- a/src/defaults/queue.js
+++ b/src/defaults/queue.js
@@ -8,7 +8,8 @@ function dequeue(array, _item) {
   return rest;
 }
 
-function peek(array) {
+// eslint-disable-next-line no-unused-vars
+function peek(array, action) {
   return array[0];
 }
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -19,7 +19,7 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (
   // find any actions to send, if any
   const state: AppState = store.getState();
   const offline = config.offlineStateLens(state).get;
-  const offlineAction = config.queue.peek(offline.outbox);
+  const offlineAction = config.queue.peek(offline.outbox, action);
 
   // create promise to return on enqueue offline action
   if (action.meta && action.meta.offline) {


### PR DESCRIPTION
Since we have the wonderful option to handle the queue, I don't see why couldn't we see the action, that runs through the offline middleware, while we peek.

## Personal reason:

In my current project I had to store every offline action that discarded and had an *invalid error response.

>*invalid: In this case, every response thats status is lower than 400 and higher than 499

Because I wanted to store them in their original place `outbox`, I had to know what is the current action that is going through the middleware, so I could return the right next action.

```javascript
/**
* The actual code, that I'm using to return the next action in peek()
*/
const nextAction = null;
for (let i = 0; i< outbox.length; i++) {
 const offlineAction = outbox[i];
  if (
    // A boolean value, that I add to the meta, to mark the preservable actions 
    !offlineAction.meta.preserve
    // The reason for the action parameter. Return the current actions equivalent part from the outbox
    || action.type === offlineAction.type
    // If there are more discarded action in the outbox, call the next one, if this one succeeded
    || action.type === offlineAction.meta.offline.commit.type
  ) {
    nextAction = offlineAction;
    break;
}
return nextAction;