### PR TITLE
Fix decorate actions section of quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const followUser = userId => ({
       // the network action to execute:
       effect: { url: '/api/follow', method: 'POST', body: { userId } },
       // action to dispatch when effect succeeds:
-      commit: { type: 'FOLLOW_USER_COMMIT', meta: { userId } },
+      commit: { type: 'FOLLOW_USER_COMMIT', meta: JSON.stringify({ userId }) },
       // action to dispatch if network action fails permanently:
       rollback: { type: 'FOLLOW_USER_ROLLBACK', meta: { userId } }
     }

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ const followUser = userId => ({
   meta: {
     offline: {
       // the network action to execute:
-      effect: { url: '/api/follow', method: 'POST', body: { userId } },
+      effect: { url: '/api/follow', method: 'POST', body: JSON.stringify({ userId }) },
       // action to dispatch when effect succeeds:
-      commit: { type: 'FOLLOW_USER_COMMIT', meta: JSON.stringify({ userId }) },
+      commit: { type: 'FOLLOW_USER_COMMIT', meta: { userId } },
       // action to dispatch if network action fails permanently:
       rollback: { type: 'FOLLOW_USER_ROLLBACK', meta: { userId } }
     }


### PR DESCRIPTION
The example passed an object as the body, which is not supported. Body in this case should be a JSON string.