### PR TITLE
Fix: createOffline persist docs

### DIFF
--- a/docs/api/create-offline.md
+++ b/docs/api/create-offline.md
@@ -10,7 +10,7 @@ import config from '@redux-offline/redux-offline/lib/defaults';
 const { middleware, enhanceReducer, enhanceStore } = createOffline(config);
 const store = createStore(
   enhanceReducer(myReducer),
-  compose(applyMiddleware(middleware), enhanceStore)
+  compose(enhanceStore, applyMiddleware(middleware))
 );
 ```
 

--- a/docs/recipes/redux-saga.md
+++ b/docs/recipes/redux-saga.md
@@ -35,7 +35,7 @@ const {
   } = createOffline(offlineConfig);
 const middleware = applyMiddleware(...middlewareList, offlineMiddleware);
 
-const store = createStore(enhanceReducer(reducer), compose(middleware, enhanceStore));
+const store = createStore(enhanceReducer(reducer), compose(enhanceStore, middleware));
 sagaMiddleware.run(helloSaga);
 ```
 


### PR DESCRIPTION
The redux-offline `peek`s the offlineAction to process everytime an action goes through the middleware chain. This works fine for actions dispatched in the same session. However when the store gets rehydrated if there's actions on the outbox, these will remain there until an action is dispatched. This is because, the offline middleware is registered after the persist has been configured so the `PERSIST_REHYDRATE` action doesn't trigger the offline process.

The solution is to simply apply middleware before enhancing the store.

More info https://github.com/Vizzuality/forest-watcher/pull/303