### PR TITLE
Fix missing Offline/Busy action

### DIFF
--- a/src/__tests__/send.js
+++ b/src/__tests__/send.js
@@ -38,8 +38,13 @@ function setup(partialConfig) {
 
 test('dispatches busy action', () => {
   const { action, config, dispatch } = setup();
-  send(action, dispatch, config);
-  expect(dispatch).toBeCalledWith(busy(true));
+  const promise = send(action, dispatch, config);
+
+  expect.assertions(2);
+  return promise.then(() => {
+    expect(dispatch).toBeCalledWith(busy(true));
+    expect(dispatch).toHaveBeenLastCalledWith(busy(false));
+  });
 });
 
 test('requests resource using effects reconciler', () => {

--- a/src/send.js
+++ b/src/send.js
@@ -68,7 +68,8 @@ const send = (action: OfflineAction, dispatch, config: Config, retries = 0) => {
       }
 
       return dispatch(complete(rollbackAction, false, error, action, config));
-    });
+    })
+    .finally(() => dispatch(busy(false)));
 };
 
 export default send;

--- a/src/updater.js
+++ b/src/updater.js
@@ -65,7 +65,6 @@ const buildOfflineUpdater = (dequeue, enqueue) =>
     if (action.type === OFFLINE_SCHEDULE_RETRY) {
       return {
         ...state,
-        busy: false,
         retryScheduled: true,
         retryCount: state.retryCount + 1
       };
@@ -104,8 +103,7 @@ const buildOfflineUpdater = (dequeue, enqueue) =>
       return {
         ...state,
         outbox: dequeue(outbox, action, { offline }),
-        retryCount: 0,
-        busy: false
+        retryCount: 0
       };
     }
 


### PR DESCRIPTION
Fixes #223 
Don't mask changing busy state on `complete`/`retry` actions. Restore previously removed functionality emitting `Offline/Busy: true/false` as last `send` action.