### PR TITLE
Detach promises from queue order

### DIFF
--- a/src/__tests__/offlineActionTracker.js
+++ b/src/__tests__/offlineActionTracker.js
@@ -41,14 +41,13 @@ test('does not resolve first action with incorrect transaction', () => {
   return promise.then(value => expect(value).toEqual(correctData));
 });
 
-test('does not resolve second action with correct transaction', () => {
+test('resolves second action with correct transaction', () => {
   const array = [];
 
   registerAction(0).then(() => array.push(0));
   const promise = registerAction(1).then(() => array.push(1));
   resolveAction(1);
   resolveAction(0);
-  resolveAction(1);
 
   expect.assertions(1);
   return promise.then(() => expect(array).toEqual([0, 1]));

--- a/src/__tests__/offlineActionTracker.js
+++ b/src/__tests__/offlineActionTracker.js
@@ -50,5 +50,5 @@ test('resolves second action with correct transaction', () => {
   resolveAction(0);
 
   expect.assertions(1);
-  return promise.then(() => expect(array).toEqual([0, 1]));
+  return promise.then(() => expect(array).toEqual([1, 0]));
 });

--- a/src/offlineActionTracker.js
+++ b/src/offlineActionTracker.js
@@ -1,24 +1,24 @@
-const subscriptions = [];
+const subscriptions = {};
 
 function registerAction(transaction) {
   return new Promise((resolve, reject) => {
-    subscriptions.push({ transaction, resolve, reject });
+    subscriptions[transaction] = { resolve, reject };
   });
 }
 
 function resolveAction(transaction, value) {
-  const subscription = subscriptions[0];
-  if (subscription && subscription.transaction === transaction) {
+  const subscription = subscriptions[transaction];
+  if (subscription) {
     subscription.resolve(value);
-    subscriptions.shift();
+    delete subscriptions[transaction];
   }
 }
 
 function rejectAction(transaction, error) {
-  const subscription = subscriptions[0];
-  if (subscription && subscription.transaction === transaction) {
+  const subscription = subscriptions[transaction];
+  if (subscription) {
     subscription.reject(error);
-    subscriptions.shift();
+    delete subscriptions[transaction];
   }
 }
 


### PR DESCRIPTION
The promises aren't necessarily in the same order as the offline queue. The [queue actions](https://github.com/redux-offline/redux-offline/blob/develop/docs/api/config.md#queue) could technically reorder the queue and ideas like [smart-queue](https://github.com/redux-offline/queue/tree/master/smart-queue) show real world situations that this would actually happen. We can't add promises to a queue and be certain they maintain a one-to-one relationship with the offline queue.

While this PR doesn't handle what happens to promises whose corresponding transactions are deleted, it will be more resilient with the transactions that do remain.