### PR TITLE
Remove diff formatting from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ Persistent Redux store for _Reasonaboutable_:tm: Offline-First applications, wit
 ## Quick start
 
 ##### 1. Install with npm (or [Yarn](https://yarnpkg.com))
-```diff
-- npm install --save redux-offline
-+ npm install --save @redux-offline/redux-offline
+```shell
+npm install --save @redux-offline/redux-offline
 ```
 
 ##### 2. Add the `offline` [store enhancer](http://redux.js.org/docs/Glossary.html#store-enhancer) with `compose`

--- a/README.md
+++ b/README.md
@@ -26,25 +26,21 @@ Persistent Redux store for _Reasonaboutable_:tm: Offline-First applications, wit
 ```
 
 ##### 2. Add the `offline` [store enhancer](http://redux.js.org/docs/Glossary.html#store-enhancer) with `compose`
-```diff
+```js
 
-- import { applyMiddleware, createStore } from 'redux';
-+ import { applyMiddleware, createStore, compose } from 'redux';
-- import { offline } from 'redux-offline';
-+ import { offline } from '@redux-offline/redux-offline';
-- import offlineConfig from 'redux-offline/lib/defaults';
-+ import offlineConfig from '@redux-offline/redux-offline/lib/defaults';
+import { applyMiddleware, createStore, compose } from 'redux';
+import { offline } from '@redux-offline/redux-offline';
+import offlineConfig from '@redux-offline/redux-offline/lib/defaults';
 
 // ...
 
 const store = createStore(
   reducer,
   preloadedState,
--  applyMiddleware(middleware)
-+  compose(
-+    applyMiddleware(middleware),
-+    offline(offlineConfig)
-+  )
+  compose(
+    applyMiddleware(middleware),
+    offline(offlineConfig)
+  )
 );
 ```
 


### PR DESCRIPTION
I'm not sure if this was on purpose, but some of the example code had diff formatting, which was a bit confusing. This commit removes the diff's deleted lines and changes the formatting back to JS.