### PR TITLE
Support 'json' property in effect in addition to 'body'

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,30 @@ const followUser = userId => ({
   meta: {
     offline: {
       // the network action to execute:
-      effect: { url: '/api/follow', method: 'POST', body: JSON.stringify({ userId }) },
+      effect: { url: '/api/follow', method: 'POST', json: { userId } },
       // action to dispatch when effect succeeds:
       commit: { type: 'FOLLOW_USER_COMMIT', meta: { userId } },
       // action to dispatch if network action fails permanently:
       rollback: { type: 'FOLLOW_USER_ROLLBACK', meta: { userId } }
+    }
+  }
+});
+```
+
+If the effect payload is something other than JSON you can pass the body and headers:
+
+```js
+const followUser = userId => ({
+  type: 'REGISTER_USER',
+  payload: { name, email },
+  meta: {
+    offline: {
+      // the network action to execute:
+      effect: { url: '/api/register', method: 'POST', body: `name=${name}&email=${email}`, headers: { 'content-type': 'application/x-www-form-urlencoded' } },
+      // action to dispatch when effect succeeds:
+      commit: { type: 'REGISTER_USER_COMMIT', meta: { name, email } },
+      // action to dispatch if network action fails permanently:
+      rollback: { type: 'REGISTER_USER_ROLLBACK', meta: { name, email } }
     }
   }
 });

--- a/src/__tests__/defaults/effect.js
+++ b/src/__tests__/defaults/effect.js
@@ -35,6 +35,33 @@ test('effector accept JSON stringified object', () => {
   });
 });
 
+test('effector accept JSON object', () => {
+  const json = {
+    email: 'email@example.com',
+    password: 'p4ssw0rd'
+  };
+
+  global.fetch = jest.fn((url, options) => {
+    expect(options.headers['content-type']).toEqual('application/json');
+    expect(JSON.parse(options.body)).toEqual(json);
+
+    return fetch('');
+  });
+
+  return effectReconciler({ json }).then(body2 => {
+    expect(body2).toEqual(null);
+  });
+});
+
+test('effector rejects invalid JSON object', () => {
+  const circularObject = {};
+  circularObject.self = circularObject;
+
+  return effectReconciler({ json: circularObject }).catch(error => {
+    expect(error).toBeInstanceOf(TypeError);
+  });
+});
+
 test('effector receive JSON and response objects', () => {
   const body = { id: 1234 };
 

--- a/src/defaults/effect.js
+++ b/src/defaults/effect.js
@@ -33,8 +33,15 @@ const getResponseBody = (res: any): Promise<{} | string> => {
 
 // eslint-disable-next-line no-unused-vars
 export default (effect: any, _action: OfflineAction): Promise<any> => {
-  const { url, ...options } = effect;
+  const { url, json, ...options } = effect;
   const headers = { 'content-type': 'application/json', ...options.headers };
+  if (json !== null && json !== undefined) {
+    try {
+      options.body = JSON.stringify(json);
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  }
   return fetch(url, { ...options, headers }).then(res => {
     if (res.ok) {
       return getResponseBody(res);


### PR DESCRIPTION
It seems lacking to not support converting to JSON when there is support
for converting from JSON. I would argue that the content type should not
default to "application/json" unless opting to use the `json` property.

Example:

```javascript
const requestAction => ({
  type: 'REQUEST_ACTION',
  effect: {
    json: {data: {...}},
  }
}

// Is the same as
const requestAction => ({
  type: 'REQUEST_ACTION',
  effect: {
    body: JSON.stringify({data: {...}}),
  }
}

// Must specify header because it defaults to "application/json"
const requestAction => ({
  type: 'REQUEST_ACTION',
  effect: {
    body: formData,
    headers: {
      'content-type': 'multipart/form-data',
    }
  }
}
```

Alternatively since `fetch` only supports Blob, BufferSource, FormData,
URLSearchParams, and USVString, to make it so anything everything else
will be converted to JSON.