### PR TITLE
Fix: adds support for capitalized Content-Type header

### DIFF
--- a/src/__tests__/defaults/effect.js
+++ b/src/__tests__/defaults/effect.js
@@ -1,4 +1,4 @@
-import effectReconciler from '../../defaults/effect';
+import effectReconciler, { getHeaders } from '../../defaults/effect';
 
 function fetch(body) {
   return Promise.resolve({
@@ -69,5 +69,27 @@ test('effector receive JSON and response objects', () => {
 
   return effectReconciler({}).then(body2 => {
     expect(body2).toEqual(body);
+  });
+});
+
+test('effector accepts content-type and Content-Type headers', () => {
+  const otherHeaders = { 'other-one': 'other-one', 'other-two': 'other-two' };
+  const formUrlEncoded = 'application/x-www-form-urlencoded';
+
+  const noHeaders = undefined;
+  const capitalizedHeaders = {
+    'Content-Type': formUrlEncoded,
+    ...otherHeaders
+  };
+  const lowerCasedHeaders = { 'content-type': formUrlEncoded, ...otherHeaders };
+
+  expect(getHeaders(noHeaders)).toEqual({ 'content-type': 'application/json' });
+  expect(getHeaders(capitalizedHeaders)).toEqual({
+    'content-type': formUrlEncoded,
+    ...otherHeaders
+  });
+  expect(getHeaders(lowerCasedHeaders)).toEqual({
+    'content-type': formUrlEncoded,
+    ...otherHeaders
   });
 });

--- a/src/defaults/effect.js
+++ b/src/defaults/effect.js
@@ -31,10 +31,22 @@ const getResponseBody = (res: any): Promise<{} | string> => {
   return res.text();
 };
 
+export const getHeaders = (headers: {}): {} => {
+  const {
+    'Content-Type': contentTypeCapitalized,
+    'content-type': contentTypeLowerCase,
+    ...restOfHeaders
+  } = headers || {};
+  const contentType =
+    contentTypeCapitalized || contentTypeLowerCase || 'application/json';
+  return { ...restOfHeaders, 'content-type': contentType };
+};
+
 // eslint-disable-next-line no-unused-vars
 export default (effect: any, _action: OfflineAction): Promise<any> => {
   const { url, json, ...options } = effect;
-  const headers = { 'content-type': 'application/json', ...options.headers };
+  const headers = getHeaders(options.headers);
+
   if (json !== null && json !== undefined) {
     try {
       options.body = JSON.stringify(json);

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,17 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-create-class-features-plugin@^7.2.1":
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.2.1.tgz#f6e8027291669ef64433220dc8327531233f1161"
+  integrity sha512-EsEP7XLFmcJHjcuFYBxYD1FkP0irC8C9fsrt2tX/jrAi/eTnFI6DOPgVFb+WREeg1GboF+Ib+nCHbGBodyAXSg==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+
 "@babel/helper-define-map@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz#3b74caec329b3c80c116290887c0dd9ae468c20c"
@@ -217,6 +228,14 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.0.0"
 
+"@babel/plugin-proposal-class-properties@^7.1.0":
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.2.1.tgz#c734a53e0a1ec40fe5c22ee5069d26da3b187d05"
+  integrity sha512-/4FKFChkQ2Jgb8lBDsvFX496YTi7UWTetVgS8oJUpX1e/DlaoeEK57At27ug8Hu2zI2g8bzkJ+8k9qrHZRPGPA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.2.1"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-proposal-json-strings@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz#3b4d7b5cf51e1f2e70f52351d28d44fc2970d01e"
@@ -249,12 +268,6 @@
 "@babel/plugin-syntax-async-generators@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz#bf0891dcdbf59558359d0c626fdc9490e20bc13c"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-syntax-class-properties@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz#e051af5d300cbfbcec4a7476e37a803489881634"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
This PR fixes #288 , we're setting as default content type `application/json`, if a user wants to override it he could pass `content-type` property inside the effect headers, however if the user provided `Content-Type` both headers were added to the request. This ensures that we only apply the default header if neither of them are passed.