### PR TITLE
Adds missing type-defs to TypeScript def file

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -107,7 +107,9 @@ declare module '@redux-offline/redux-offline/lib/types' {
       registerAction: (transaction: number) => Promise<any> | (() => void),
       resolveAction: (transaction: number, value: any) => void | (() => void),
       rejectAction: (transaction: number, error: Error) => void | (() => void)
-    }
+    };
+    returnPromises?: boolean;
+    rehydrate?: boolean;
   }
 }
 


### PR DESCRIPTION
This PR adds the missing config types from `types.js` to TypeScript definition file.

I wanted to make the `rehydrate` parameter `false`. But TypeScript wasn't allowing as it doesn't exist on the interface.