### PR TITLE
Added missing TypeScript type Config.returnPromises

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -86,6 +86,7 @@ declare module '@redux-offline/redux-offline/lib/types' {
     persistCallback: (callback?: any) => any;
     persistOptions: { [key: string]: any };
     retry: (action: OfflineAction, retries: number) => number | void;
+    returnPromises: boolean;
     queue: {
       enqueue: (
         array: Array<OfflineAction>,


### PR DESCRIPTION
Noticed this was missing. If I'm not mistaken it is a bug.