### PR TITLE
fix for sending FormData after restart the app

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,10 +3,12 @@ module.exports = {
   extends: ['airbnb-base', 'plugin:flowtype/recommended', 'prettier'],
   plugins: ['flowtype', 'prettier'],
   globals: {
-    Promise: true
+    Promise: true,
+    document: false // https://stackoverflow.com/a/41922950/3481005
   },
   env: {
     jest: true,  // https://stackoverflow.com/a/40265356/586382
+    browser: true, // https://stackoverflow.com/a/41922950/3481005
     node: true
   },
   rules: {

--- a/src/defaults/effect.js
+++ b/src/defaults/effect.js
@@ -42,29 +42,32 @@ export const getHeaders = (headers: {}): {} => {
   return { ...restOfHeaders, 'content-type': contentType };
 };
 
-export const getFormData = (object) => {
-
+export const getFormData = object => {
   const formData = new FormData();
 
-  for (var key in object) {
-    for (var innerObj in object[key]) {
-      var newObj = object[key][innerObj]
+  Object.keys(object).forEach(key => {
+    Object.keys(object[key]).forEach(innerObj => {
+      const newObj = object[key][innerObj];
       formData.append(newObj[0], newObj[1]);
-    }
-  }
+    });
+  });
 
   return formData;
-}
+};
 
 // eslint-disable-next-line no-unused-vars
 export default (effect: any, _action: OfflineAction): Promise<any> => {
   const { url, json, ...options } = effect;
   const headers = getHeaders(options.headers);
 
-  if (!(options.body instanceof FormData) && headers.hasOwnProperty('content-type') && headers['content-type'].includes('multipart/form-data'))
-    options.body = getFormData(options.body)
+  if (
+    !(options.body instanceof FormData) &&
+    Object.prototype.hasOwnProperty.call(headers, 'content-type') &&
+    headers['content-type'].includes('multipart/form-data')
+  )
+    options.body = getFormData(options.body);
 
-    if (json !== null && json !== undefined) {
+  if (json !== null && json !== undefined) {
     try {
       options.body = JSON.stringify(json);
     } catch (e) {

--- a/src/defaults/effect.js
+++ b/src/defaults/effect.js
@@ -42,12 +42,29 @@ export const getHeaders = (headers: {}): {} => {
   return { ...restOfHeaders, 'content-type': contentType };
 };
 
+export const getFormData = (object) => {
+
+  const formData = new FormData();
+
+  for (var key in object) {
+    for (var innerObj in object[key]) {
+      var newObj = object[key][innerObj]
+      formData.append(newObj[0], newObj[1]);
+    }
+  }
+
+  return formData;
+}
+
 // eslint-disable-next-line no-unused-vars
 export default (effect: any, _action: OfflineAction): Promise<any> => {
   const { url, json, ...options } = effect;
   const headers = getHeaders(options.headers);
 
-  if (json !== null && json !== undefined) {
+  if (!(options.body instanceof FormData) && headers.hasOwnProperty('content-type') && headers['content-type'].includes('multipart/form-data'))
+    options.body = getFormData(options.body)
+
+    if (json !== null && json !== undefined) {
     try {
       options.body = JSON.stringify(json);
     } catch (e) {


### PR DESCRIPTION
This PR fixes https://github.com/redux-offline/redux-offline/issues/330

Basically I noticed that when you close the app, everything is saved in AsyncStorage (by default) by stringifying the body. After that, when you open the app, the json of the body will be parsed. In this way you lose the FormData structure.
So what I did is check if the effect request has a content-type 'multipart/form-data' in order to recreate the FormData structure from the previous one.