### PR TITLE
React Native 0.60.x compatiblity

### DIFF
--- a/src/defaults/detectNetwork.native.js
+++ b/src/defaults/detectNetwork.native.js
@@ -1,5 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
-import { AppState, NetInfo } from 'react-native'; // eslint-disable-line
+import { AppState } from 'react-native'; // eslint-disable-line
+import NetInfo from '@react-native-community/netinfo';
 import LegacyDetectNetwork from './detectNetwork.native.legacy';
 
 class DetectNetwork {

--- a/src/defaults/detectNetwork.native.js
+++ b/src/defaults/detectNetwork.native.js
@@ -1,6 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
 import { AppState } from 'react-native'; // eslint-disable-line
-import NetInfo from '@react-native-community/netinfo';
+import NetInfo from '@react-native-community/netinfo'; // eslint-disable-line
 import LegacyDetectNetwork from './detectNetwork.native.legacy';
 
 class DetectNetwork {

--- a/src/defaults/detectNetwork.native.legacy.js
+++ b/src/defaults/detectNetwork.native.legacy.js
@@ -1,6 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
 import { AppState } from 'react-native'; // eslint-disable-line
-import NetInfo from '@react-native-community/netinfo';
+import NetInfo from '@react-native-community/netinfo'; // eslint-disable-line
 
 class LegacyDetectNetwork {
   constructor(callback) {

--- a/src/defaults/detectNetwork.native.legacy.js
+++ b/src/defaults/detectNetwork.native.legacy.js
@@ -1,5 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
-import { AppState, NetInfo } from 'react-native'; // eslint-disable-line
+import { AppState } from 'react-native'; // eslint-disable-line
+import NetInfo from '@react-native-community/netinfo';
 
 class LegacyDetectNetwork {
   constructor(callback) {


### PR DESCRIPTION
Use @react-native-community/netinfo for react native 0.60.x compatibility. This is a breaking change for react native < 0.60.x users.