### PR TITLE
Check for existence of NetInfo

### DIFF
--- a/src/defaults/detectNetwork.native.js
+++ b/src/defaults/detectNetwork.native.js
@@ -144,6 +144,6 @@ class DetectNetwork {
   };
 }
 
-const isLegacy = typeof NetInfo.getConnectionInfo === 'undefined';
+const isLegacy = NetInfo && typeof NetInfo.getConnectionInfo === 'undefined';
 export default callback =>
   isLegacy ? new LegacyDetectNetwork(callback) : new DetectNetwork(callback);


### PR DESCRIPTION
Fixes crash in RN 0.60.4.

`NetInfo` does not existed in `react-native` core anymore, hence this line causes crash because `NetInfo` is `undefined`. This patch fixes that.