### PR TITLE
fix: use @react-native-community/netinfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "redux-persist": "^4.6.0"
   },
   "peerDependencies": {
+    "@react-native-community/netinfo": "^4.1.3",
     "redux": ">=3"
   }
 }

--- a/src/defaults/detectNetwork.native.js
+++ b/src/defaults/detectNetwork.native.js
@@ -1,5 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
-import { AppState, NetInfo } from 'react-native'; // eslint-disable-line
+import { AppState } from 'react-native'; // eslint-disable-line
+import NetInfo from "@react-native-community/netinfo";
 import LegacyDetectNetwork from './detectNetwork.native.legacy';
 
 class DetectNetwork {

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,6 +941,11 @@
     node-fetch "^2.1.1"
     url-template "^2.0.8"
 
+"@react-native-community/netinfo@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-4.1.3.tgz#77571619eb90ff59777a85a913fc30acd30b6020"
+  integrity sha512-c9ppXNFpKkXiKFJhik9Lzw62dosm+cAIvHl6OOGXp2D+1GlliIP+nMMtNapdppPoilRc33f4/GosqnL70viH9Q==
+
 "@types/babel__core@^7.1.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.2.tgz#608c74f55928033fce18b99b213c16be4b3d114f"


### PR DESCRIPTION
NetInfo was split out from the core of React Native and now it exists as a separate module here: https://github.com/react-native-community/react-native-netinfo

This PR will use the new official module instead of the deprecated one.