### PR TITLE
Update example code for action queue config

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -166,13 +166,17 @@ const getMethod = action => action.meta.offline.effect.method || "GET";
 const getUrl = action => action.meta.offline.effect.url;
 
 // Last Value Queue
-// Only keep the last action for each URL-method pair.
+// Only keep the last action for each URL-method pair,
+// except for the first item in the queue which may have already triggered its initial effect
 const config = {
   queue: {
     ...defaultQueue,
     enqueue(array, action) {
-      const newArray = array.filter(item =>
-        !(getMethod(item) === getMethod(action) && getUrl(item) === getUrl(action))
+      const newArray = array.filter((item, index) =>
+        !(
+          getMethod(item) === getMethod(action) &&
+          getUrl(item) === getUrl(action)) &&
+          index !== 0 
       );
       newArray.push(action);
       return newArray;


### PR DESCRIPTION
It's awesome the docs had example code for [this](https://github.com/redux-offline/redux-offline/blob/develop/docs/api/config.md#queueenqueue), but it bit us early with what I expect is a common use case.

It doesn't matter at all for GET actions, but say you're using the example code for a POST action to toggle a state using a REST endpoint. The repro is you toggle it twice quickly, before the first POST has time to return.

Using the example code, the first action, which has already triggered the initial `effect` call, gets replaced by the second one, even though the network event for the first even has already been dispatched.

The second actions initial `effect` call then does not get triggered, and I'm pretty sure it executes it's own `commit` and `rollback` actions once the network calls complete.

The result of doing this with a simple toggle is local state reflects the double toggle, where the server state reflects only the first toggle.

I'd say it's a sensible change for the example code to not remove the 0-indexed item on the queue which may have already triggered an effect and be waiting for a network response, yes?

I'd be happy to put together a Sandbox example if you don't believe me from the writeup 😄 .