### PR TITLE
Support Expo SDK 36

### DIFF
--- a/src/defaults/persist.native.js
+++ b/src/defaults/persist.native.js
@@ -2,7 +2,7 @@
 
 // $FlowIgnore
 import { persistStore } from 'redux-persist';
-import AsyncStorage from '@react-native-community/async-storage'; // eslint-disable-line
+import { AsyncStorage } from "react-native"; // eslint-disable-line
 
 export default (store: any, options: {}, callback: any) =>
   persistStore(store, { storage: AsyncStorage, ...options }, callback);


### PR DESCRIPTION
Expo 36 bumped the React Native version above 0.60 thus requiring the native branch. Unfortunately, the native branch also switches to using `@react-native-community/async-storage` which is not supported by expo. This pull request restores support for Expo 36 by moving back to the deprecated `import { AsyncStorage } from "react-native";` until such a time that Expo adds support.

I am unsure whether the community would want to move back to react-native AsyncStorage since it is deprecated, but for the significant number of developers using managed Expo they cannot use `@react-native-community/async-storage` until Expo chooses to support it. It might be best to put this on its own branch, or simply leave it here so other developers who upgrade to Expo 36 can still figure out how to use redux offline with Expo 36.

I'm still somewhat new to redux-offline, so if I missed anything please let me know. 