### PR TITLE
Empty outbox

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
   * [Customize Requests](recipes/customize-requests.md)
   * [Immutable.js](recipes/immutable.md)
   * [Redux-Saga](recipes/redux-saga.md)
+  * [Empty outbox](recipes/empty-outbox.md)
 * Troubleshooting
   * [Offline queue doesn't trigger on network status change](recipes/troubleshooting/offline-queue-trigger.md)
 * API Reference

--- a/docs/recipes/empty-outbox.md
+++ b/docs/recipes/empty-outbox.md
@@ -1,0 +1,10 @@
+# Empty Outbox
+
+If you want to drop any unresolved offline actions (for instance when a user logs out, switches to a different organisation)
+
+Dispatch a reset state event as follows:
+
+```js
+import { RESET_STATE } from "@redux-offline/redux-offline/lib/constants";
+store.dispatch({ type: RESET_STATE });
+```


### PR DESCRIPTION
Added info on how to clear the outbox, this was in README.md (https://github.com/redux-offline/redux-offline/commit/8a943c94c1baa57db2cb034c87e44d1e8bd1abf7) but appears to have been removed and I couldn't see it in current docs.