### PR TITLE
Don't monkey patch replaceReducer in createOffline

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -34,7 +34,8 @@ type Config = {
     ) => OfflineAction
   },
   retry: (action: OfflineAction, retries: number) => ?number,
-  returnPromises: boolean
+  returnPromises: boolean,
+  enhanceReplaceReducer: boolean
 };
 ```
 
@@ -217,3 +218,9 @@ If a request fails after this point, it will be discarded.
 Toggle whether dispatch returns promises for offline actions. Defaults to false.
 
 `store.dispatch()` returns a promise that you can use to chain behavior off offline actions, but be careful! A chief benefit of this library is that requests are tried across sessions, but promises do not last that long. So if you use this feature, know that your promise might not get resolved, even if the associated request is eventually delivered.
+
+## enhanceReplaceReducer
+
+Only for `createOffline()`.
+
+Allows disabling monkey patching `store.replaceReducer()` to give more control over exactly when `enhanceReducer` is called. Must be explicitly set to `false` to take effect.

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -64,6 +64,28 @@ test("createOffline() supports HMR", () => {
   expect(store.getState()).toHaveProperty("offline");
 });
 
+test("createOffline() does not enhance the reducer if enhanceReplaceReducer is false", () => {
+  const {middleware, enhanceReducer, enhanceStore} = createOffline({
+    ...defaultConfig,
+    enhanceReplaceReducer: false
+  });
+  const reducer = enhanceReducer(defaultReducer);
+  const store = createStore(
+    reducer,
+    compose(
+      applyMiddleware(middleware),
+      enhanceStore
+    )
+  );
+  store.replaceReducer(
+    combineReducers({
+      data: defaultReducer
+    })
+  );
+  store.dispatch({type: "SOME_ACTION"});
+  expect(store.getState()).not.toHaveProperty("offline");
+})
+
 // see https://github.com/redux-offline/redux-offline/issues/4
 test("restores offline outbox when rehydrates", done => {
   const actions = [{

--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,16 @@
 // @flow
 /* global $Shape */
-import type { Config } from './types';
+import type { AdvancedConfig, Config } from './types';
 import defaults from './defaults';
 
 export const applyDefaults = (config: $Shape<Config> = {}): Config => ({
+  ...defaults,
+  ...config
+});
+
+export const applyAdvancedDefaults = (
+  config: $Shape<AdvancedConfig> = {}
+): AdvancedConfig => ({
   ...defaults,
   ...config
 });

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -18,6 +18,12 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (
   // find any actions to send, if any
   const state: AppState = store.getState();
   const offline = config.offlineStateLens(state).get;
+  if (offline == null) {
+    console.warn(
+      'No offline state was found. Offline actions are not being processed.'
+    );
+    return result;
+  }
   const context = { offline };
   const offlineAction = config.queue.peek(offline.outbox, action, context);
 

--- a/src/types.js
+++ b/src/types.js
@@ -125,3 +125,7 @@ export type Config = {
   returnPromises?: boolean,
   rehydrate?: boolean
 };
+
+export type AdvancedConfig = Config & {
+  enhanceReplaceReducer?: boolean
+};

--- a/src/types.js
+++ b/src/types.js
@@ -99,7 +99,7 @@ export type Config = {
   persistAutoRehydrate: (config: ?{}) => (next: any) => any,
   offlineStateLens: (
     state: any
-  ) => { get: OfflineState, set: (offlineState: ?OfflineState) => any },
+  ) => { get: ?OfflineState, set: (offlineState: ?OfflineState) => any },
   queue: {
     enqueue: (
       array: Array<OfflineAction>,

--- a/src/updater.js
+++ b/src/updater.js
@@ -136,6 +136,8 @@ export const enhanceReducer = (reducer: any, config: $Shape<Config>) => {
 
     return config
       .offlineStateLens(reducer(restState, action))
-      .set(offlineUpdater(offlineState, action));
+      .set(
+        offlineUpdater(offlineState == null ? undefined : offlineState, action)
+      );
   };
 };


### PR DESCRIPTION
We are using redux-offline with redux-persist v5, following the example from [the README](https://github.com/redux-offline/redux-offline/tree/6d7bf55aa22220b71be890f1cb7fb4ece0f85352#miscellanea), whereby our reducer is wrapped with `offlineEnhanceReducer` which is in turn wrapped with `persistReducer`. This works perfectly when we initially create the store, but our use case requires replacing the reducer at runtime, so we are calling `store.replaceReducer` with another reducer which is wrapped with `offlineEnhanceReducer` and `persistReducer` as above.

The problem which we are encountering is that the new reducer is [being wrapped again with `ehanceReducer`](https://github.com/redux-offline/redux-offline/blob/6d7bf55aa22220b71be890f1cb7fb4ece0f85352/src/index.js#L116) inside the monkey patched `replaceReducer` function, which means that we end up with a reducer which has been enhanced with the offline functionality twice. Because we need to wrap the reducer in `persistReducer` *after* it is wrapped in `enhanceReducer` we can't just pass in an unenhanced reducer to the replace function.

Our code looks something like this:

```js
const offline = createOffline({
  ...offlineConfig,
  persist: false
});

// The initial reducer.
const persistedReducer = persistReducer(
  persistConfig,
  offline.enhanceReducer(reducer)
);

const store = createStore(
  persistedReducer,
  compose(
    offline.enhanceStore,
    applyMiddleware(thunk, offline.middleware)
  )
);

// The new reducer.
const newPersistedReducer = persistReducer(
  someOtherPersistConfig,
  offline.enhanceReducer(reducer)
);

store.replaceReducer(newPersistedReducer);
```

The `createOffline` function is supposed to let the developer decide where to insert each of `middleware`, `enhanceStore` and `enhanceReducer` in the code, but the monkey patch always wraps the next reducer with `enhanceReducer`.

Removing the monkey patch allows the new reducer to be wrapped where it makes sense so that the same flexibility is available when replacing the reducer as was available for the initial reducer when the store was created.