### PR TITLE
removed file that prevented alternative storage engines

### DIFF
--- a/src/defaults/persist.native.js
+++ b/src/defaults/persist.native.js
@@ -1,8 +1,0 @@
-// @flow
-
-// $FlowIgnore
-import { AsyncStorage } from 'react-native'; // eslint-disable-line
-import { persistStore } from 'redux-persist';
-
-export default (store: any, options: {}, callback: any) =>
-  persistStore(store, { storage: AsyncStorage, ...options }, callback);


### PR DESCRIPTION
I was trying to use this library alongside redux persist v6 as well as [redux-persist-sensitive-storage](https://github.com/CodingZeal/redux-persist-sensitive-storage), but the app kept crashing, even after following advice on upgrading versions. I discovered a dead file whose call to async storage was causing a breaking issue for anyone not using async storage for their storage engine.