### PR TITLE
Ability to configure what happens when there are no retries left (rather than simply discarding)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ jspm_packages
 
 # yarn.lock exists so don't commit package-lock.json
 package-lock.json
+
+# editor settings
+.vscode/settings.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@
     * [defaultRollback](api/config.md#defaultrollback)
     * [detectNetwork](api/config.md#detectnetwork)
     * [discard](api/config.md#discard)
+    * [discardOnRetryCountExceeded](api/config.md#discardOnRetryCountExceeded)
     * [effect](api/config.md#effect)
     * [offlineStateLens](api/config.md#offlinestatelens)
     * [persist](api/config.md#persist)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-offline/redux-offline",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "description": "Redux Offline-First Architecture",
   "main": "lib/index.js",
   "types": "./typings.d.ts",

--- a/src/__tests__/middleware.js
+++ b/src/__tests__/middleware.js
@@ -25,6 +25,7 @@ const defaultOfflineState = {
   receipts: [],
   retryToken: 0,
   retryCount: 0,
+  retryCountExceeded: false,
   retryScheduled: false,
   netInfo: {
     isConnectionExpensive: null,
@@ -89,6 +90,12 @@ describe('on any action', () => {
 
   it('does not process outbox when retry scheduled', () => {
     const { config, store, next, action } = setup({ retryScheduled: true });
+    createOfflineMiddleware(config)(store)(next)(action);
+    expect(send).not.toBeCalled();
+  });
+
+  it('does not process outbox when retry count exceeded', () => {
+    const { config, store, next, action } = setup({ retryCountExceeded: true });
     createOfflineMiddleware(config)(store)(next)(action);
     expect(send).not.toBeCalled();
   });

--- a/src/actions.js
+++ b/src/actions.js
@@ -2,7 +2,9 @@ import {
   OFFLINE_STATUS_CHANGED,
   OFFLINE_SCHEDULE_RETRY,
   OFFLINE_COMPLETE_RETRY,
-  OFFLINE_BUSY
+  OFFLINE_BUSY,
+  OFFLINE_RETRY_COUNT_EXCEEDED,
+  OFFLINE_RESET_RETRY_COUNT
 } from './constants';
 
 export const networkStatusChanged = params => {
@@ -28,6 +30,14 @@ export const scheduleRetry = (delay = 0) => ({
 export const completeRetry = action => ({
   type: OFFLINE_COMPLETE_RETRY,
   payload: action
+});
+
+export const retryCountExceeded = () => ({
+  type: OFFLINE_RETRY_COUNT_EXCEEDED
+});
+
+export const resetRetryCount = () => ({
+  type: OFFLINE_RESET_RETRY_COUNT
 });
 
 export const busy = isBusy => ({

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,10 @@ export const OFFLINE_SCHEDULE_RETRY: 'Offline/SCHEDULE_RETRY' =
   'Offline/SCHEDULE_RETRY';
 export const OFFLINE_COMPLETE_RETRY: 'Offline/COMPLETE_RETRY' =
   'Offline/COMPLETE_RETRY';
+export const OFFLINE_RETRY_COUNT_EXCEEDED: 'Offline/RETRY_COUNT_EXCEEDED' = 
+  'Offline/RETRY_COUNT_EXCEEDED';
+export const OFFLINE_RESET_RETRY_COUNT: 'Offline/RESET_RETRY_COUNT' = 
+  'Offline/RESET_RETRY_COUNT';
 export const OFFLINE_SEND: 'Offline/SEND' = 'Offline/SEND';
 export const OFFLINE_BUSY: 'Offline/BUSY' = 'Offline/BUSY';
 export const RESET_STATE: 'Offline/RESET_STATE' = 'Offline/RESET_STATE';

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -16,6 +16,7 @@ export default {
   effect,
   retry,
   discard,
+  discardOnRetryCountExceeded: true,
   defaultCommit,
   defaultRollback,
   persistAutoRehydrate,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -33,6 +33,7 @@ export const createOfflineMiddleware = (config: Config) => (store: any) => (
     offlineAction &&
     !offline.busy &&
     !offline.retryScheduled &&
+    !offline.retryCountExceeded &&
     offline.online
   ) {
     send(offlineAction, store.dispatch, config, offline.retryCount);

--- a/src/send.js
+++ b/src/send.js
@@ -1,5 +1,5 @@
 // @flow
-import { busy, scheduleRetry } from './actions';
+import { busy, scheduleRetry, retryCountExceeded } from './actions';
 import { JS_ERROR } from './constants';
 import type {
   Config,
@@ -93,6 +93,8 @@ const send = (
         const delay = config.retry(action, retries);
         if (delay != null) {
           return dispatch(scheduleRetry(delay));
+        } else if (!config.discardOnRetryCountExceeded) {
+          return dispatch(retryCountExceeded());
         }
       }
 

--- a/src/types.js
+++ b/src/types.js
@@ -61,7 +61,8 @@ export type OfflineState = {
   outbox: Outbox,
   netInfo?: NetInfo,
   retryCount: number,
-  retryScheduled: boolean
+  retryScheduled: boolean,
+  retryCountExceeded: boolean
 };
 
 export type PersistRehydrateAction = {
@@ -92,6 +93,7 @@ export type Config = {
   effect: (effect: any, action: OfflineAction) => Promise<*>,
   retry: (action: OfflineAction, retries: number) => ?number,
   discard: (error: any, action: OfflineAction, retries: number) => boolean,
+  discardOnRetryCountExceeded: boolean,
   persistOptions: {},
   persistCallback: (callback: any) => any,
   defaultCommit: DefaultAction,

--- a/src/updater.js
+++ b/src/updater.js
@@ -14,6 +14,8 @@ import {
   OFFLINE_STATUS_CHANGED,
   OFFLINE_SCHEDULE_RETRY,
   OFFLINE_COMPLETE_RETRY,
+  OFFLINE_RETRY_COUNT_EXCEEDED,
+  OFFLINE_RESET_RETRY_COUNT,
   OFFLINE_BUSY,
   RESET_STATE,
   PERSIST_REHYDRATE
@@ -25,6 +27,7 @@ export const initialState: OfflineState = {
   online: false,
   outbox: [],
   retryCount: 0,
+  retryCountExceeded: false,
   retryScheduled: false,
   netInfo: {
     isConnectionExpensive: null,
@@ -61,6 +64,7 @@ export const buildOfflineUpdater = (dequeue: Dequeue, enqueue: Enqueue) =>
         netInfo: state.netInfo,
         retryScheduled: initialState.retryScheduled,
         retryCount: initialState.retryCount,
+        retryCountExceeded: initialState.retryCountExceeded,
         busy: initialState.busy
       };
     }
@@ -71,6 +75,18 @@ export const buildOfflineUpdater = (dequeue: Dequeue, enqueue: Enqueue) =>
         retryScheduled: true,
         retryCount: state.retryCount + 1
       };
+    }
+
+    if (action.type === OFFLINE_RESET_RETRY_COUNT) {
+      return { 
+        ...state, 
+        retryCount: 0,
+        retryCountExceeded: false,
+       };
+    }
+
+    if (action.type === OFFLINE_RETRY_COUNT_EXCEEDED) {
+      return { ...state, retryCountExceeded: true };
     }
 
     if (action.type === OFFLINE_COMPLETE_RETRY) {
@@ -107,7 +123,8 @@ export const buildOfflineUpdater = (dequeue: Dequeue, enqueue: Enqueue) =>
       return {
         ...state,
         outbox: dequeue(offline.outbox, action, { offline }),
-        retryCount: 0
+        retryCount: 0,
+        retryCountExceeded: false
       };
     }
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -56,6 +56,7 @@ declare module '@redux-offline/redux-offline/lib/types' {
     online: boolean;
     outbox: Outbox;
     retryCount: number;
+    retryCountExceeded: boolean;
     retryScheduled: boolean;
   }
 
@@ -77,6 +78,7 @@ declare module '@redux-offline/redux-offline/lib/types' {
     defaultRollback: { type: string };
     detectNetwork: (callback: NetworkCallback) => void;
     discard: (error: any, action: OfflineAction, retries: number) => boolean;
+    discardOnRetryCountExceeded: boolean;
     effect: (effect: any, action: OfflineAction) => Promise<any>;
     offlineStateLens: (
       state: any,
@@ -121,6 +123,8 @@ declare module '@redux-offline/redux-offline/lib/constants' {
   export const RESET_STATE: string;
   export const OFFLINE_BUSY: string;
   export const OFFLINE_SEND: string;
+  export const OFFLINE_RETRY_COUNT_EXCEEDED: string;
+  export const OFFLINE_RESET_RETRY_COUNT: string;
   export const OFFLINE_COMPLETE_RETRY: string;
   export const OFFLINE_SCHEDULE_RETRY: string;
   export const OFFLINE_STATUS_CHANGED: string;


### PR DESCRIPTION
**This feature should have no effect to existing applications**

Added `config.discardOnRetryCountExceeded`, which defaults to true. Requests are discarded when there are no retries left (current behavior).

Setting the flag to false causes the request to remain in the outbox rather than be discarded. This is useful for applications that cannot afford to lose any requests due to network errors.

Added a `retryCountExceeded` flag to OfflineState to provide visibility to when the above occurs.

Added an `OFFLINE_RESET_RETRY_COUNT` action to enable resetting the retry state of the request, causing redux-offline to start over with retrying the request according to the configured decay schedule.

Updated docs.

Added some tests. I was not able to run the tests in __tests__/index.js, including an integration test that I added there.  I was getting the below error. Any idea why?

TypeError: Cannot read property 'origin' of undefined
    at Window.get localStorage [as localStorage] (C:\Users\Brad\source\repos\redux-offline\node_modules\jsdom\lib\jsdom\browser\Window.js:256:26)
    at _hasStorage (C:\Users\Brad\source\repos\redux-offline\node_modules\redux-persist\lib\defaults\asyncLocalStorage.js:89:101)
    at hasLocalStorage (C:\Users\Brad\source\repos\redux-offline\node_modules\redux-persist\lib\defaults\asyncLocalStorage.js:107:10)
    at getStorage (C:\Users\Brad\source\repos\redux-offline\node_modules\redux-persist\lib\defaults\asyncLocalStorage.js:116:12)
    at Object.<anonymous>.exports.default (C:\Users\Brad\source\repos\redux-offline\node_modules\redux-persist\lib\defaults\asyncLocalStorage.js:8:17)
    at getStoredState (C:\Users\Brad\source\repos\redux-offline\node_modules\redux-persist\lib\getStoredState.js:18:67)
    at Immediate.<anonymous> (C:\Users\Brad\source\repos\redux-offline\node_modules\redux-persist\lib\persistStore.js:43:36)
    at runCallback (timers.js:706:11)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
